### PR TITLE
fix: resolve semantic-release version synchronization issues in CI/CD…

### DIFF
--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -365,12 +365,13 @@ jobs:
           fi
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Generate changelog
+      - name: Generate changelog and update version files
         working-directory: ${{ github.workspace }}/caylent-devcontainer-cli
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
-          python -m semantic_release changelog
+          # Generate changelog AND update version files
+          python -m semantic_release version --no-push --no-vcs-release
 
       - name: Commit changelog and version bump
         id: commit-changes
@@ -391,7 +392,8 @@ jobs:
           git config --global user.email "caylent-platform-bot[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}
           git checkout -b release-$VERSION
-          git add CHANGELOG.md src/caylent_devcontainer_cli/__init__.py
+          # Add ALL version-related files that semantic-release may have updated
+          git add CHANGELOG.md src/caylent_devcontainer_cli/__init__.py pyproject.toml
           git commit -m "chore(release): $VERSION"
           git push origin release-$VERSION
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,27 +127,30 @@ jobs:
           make install
           asdf reshim
 
-      - name: Update version in package files
+      - name: Verify version consistency
         run: |
           TAG_VERSION="${{ env.TAG_VERSION }}"
           cd $GITHUB_WORKSPACE/caylent-devcontainer-cli
 
-          # Update version in __init__.py
-          if [ -f "src/caylent_devcontainer_cli/__init__.py" ]; then
-            sed -i "s/__version__ = .*/__version__ = \"$TAG_VERSION\"/" src/caylent_devcontainer_cli/__init__.py
+          # Verify that the tag version matches the version in source files
+          INIT_VERSION=$(grep '__version__ = ' src/caylent_devcontainer_cli/__init__.py | sed 's/__version__ = "\(.*\)"/\1/')
+          TOML_VERSION=$(grep 'version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+          echo "Tag version: $TAG_VERSION"
+          echo "__init__.py version: $INIT_VERSION"
+          echo "pyproject.toml version: $TOML_VERSION"
+
+          if [[ "$TAG_VERSION" != "$INIT_VERSION" ]]; then
+            echo "::error::Version mismatch: tag ($TAG_VERSION) != __init__.py ($INIT_VERSION)"
+            exit 1
           fi
 
-          # Update version in pyproject.toml if it exists
-          if [ -f "pyproject.toml" ]; then
-            sed -i "s/version = .*/version = \"$TAG_VERSION\"/" pyproject.toml
+          if [[ "$TAG_VERSION" != "$TOML_VERSION" ]]; then
+            echo "::error::Version mismatch: tag ($TAG_VERSION) != pyproject.toml ($TOML_VERSION)"
+            exit 1
           fi
 
-          # Update version in setup.py if it exists
-          if [ -f "setup.py" ]; then
-            sed -i "s/version=['\"][^'\"]*['\"]/version=\"$TAG_VERSION\"/" setup.py
-          fi
-
-          echo "Updated package version to $TAG_VERSION"
+          echo "✅ Version consistency verified: $TAG_VERSION"
 
       - name: Build package
         run: |

--- a/caylent-devcontainer-cli/CHANGELOG.md
+++ b/caylent-devcontainer-cli/CHANGELOG.md
@@ -4,6 +4,23 @@
 ## Unreleased
 
 
+## v1.5.0 (2025-08-08)
+
+### Features
+
+* feat: add manual trigger capability to publish workflow
+* feat: comprehensive dev environment optimization with enhanced quality assurance
+
+### Fixes
+
+* fix: apply pre-commit trailing whitespace fixes to publish workflow
+* fix: optimize PyPI publish workflow with comprehensive caching and enhanced semantic versioning
+
+### Chores
+
+* chore: add comprehensive caching to PyPI publish workflow
+
+
 ## v1.4.0 (2025-07-25)
 
 # 🚀 New Devcontainer CLI Release – Big Improvements! 🎉

--- a/caylent-devcontainer-cli/pyproject.toml
+++ b/caylent-devcontainer-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "caylent-devcontainer-cli"
-version = "1.4.0"
+version = "1.5.0"
 description = "CLI tool for managing Caylent devcontainers"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.8"

--- a/caylent-devcontainer-cli/src/caylent_devcontainer_cli/__init__.py
+++ b/caylent-devcontainer-cli/src/caylent_devcontainer_cli/__init__.py
@@ -1,4 +1,4 @@
 """Caylent Devcontainer CLI package."""
 
 # Direct version specification for build process
-__version__ = "1.4.0"
+__version__ = "1.5.0"


### PR DESCRIPTION
… workflows

- Fix main-validation workflow to properly update all version files (pyproject.toml, __init__.py, CHANGELOG.md)
- Use 'semantic_release version --no-push --no-vcs-release' instead of just 'changelog' command
- Add comprehensive version file commits to prevent version mismatches
- Replace manual version overrides in publish workflow with version consistency verification
- Update CHANGELOG.md to properly reflect current v1.5.0 release
- Ensures git tags point to commits with synchronized version files across all locations

This prevents the 'already released' error by maintaining proper version file synchronization and ensures semantic-release can correctly calculate next versions from commit history.