### PR TITLE
Expand devcontainer validation, CICD toggle, tooling improvements, and WSL support

### DIFF
--- a/.devcontainer/.devcontainer.postcreate.sh
+++ b/.devcontainer/.devcontainer.postcreate.sh
@@ -80,6 +80,15 @@ log_info "Configuring ENV vars..."
 echo "export PATH=\"${WORK_DIR}/.localscripts:\${PATH}\"" >> ${BASH_RC}
 echo "export PATH=\"${WORK_DIR}/.localscripts:\${PATH}\"" >> ${ZSH_RC}
 
+# Source shell.env for WSL environments
+if uname -r | grep -i microsoft > /dev/null; then
+  log_info "WSL detected - configuring shell.env sourcing for all shells"
+  echo "# Source project shell.env for WSL" >> ${BASH_RC}
+  echo "if [ -f \"${WORK_DIR}/shell.env\" ]; then source \"${WORK_DIR}/shell.env\"; fi" >> ${BASH_RC}
+  echo "# Source project shell.env for WSL" >> ${ZSH_RC}
+  echo "if [ -f \"${WORK_DIR}/shell.env\" ]; then source \"${WORK_DIR}/shell.env\"; fi" >> ${ZSH_RC}
+fi
+
 # Handle PAGER configuration by checking shell.env first
 SHELL_ENV_PAGER=""
 if [ -f "${WORK_DIR}/shell.env" ] && grep -q "^export PAGER=" "${WORK_DIR}/shell.env"; then

--- a/.devcontainer/.devcontainer.postcreate.sh
+++ b/.devcontainer/.devcontainer.postcreate.sh
@@ -295,7 +295,7 @@ echo "export PATH=\"\$PATH:/home/${CONTAINER_USER}/.local/bin\"" >> ${ZSH_RC}
 log_info "Installing Python packages..."
 if uname -r | grep -i microsoft > /dev/null; then
   # WSL compatibility: Do not use sudo -u in WSL as it fails
-  python -m pipx install aws-sso-util --root-user-action=ignore
+  python -m pipx install aws-sso-util
 else
   # Non-WSL: Use sudo -u to ensure correct user environment
   sudo -u ${CONTAINER_USER} bash -c "export PATH=\"\$PATH:/home/${CONTAINER_USER}/.local/bin\" && source /home/${CONTAINER_USER}/.asdf/asdf.sh && python -m pipx install aws-sso-util"

--- a/.devcontainer/.devcontainer.postcreate.sh
+++ b/.devcontainer/.devcontainer.postcreate.sh
@@ -11,6 +11,33 @@ WARNINGS=()
 # Source shared functions
 source "${WORK_DIR}/.devcontainer/devcontainer-functions.sh"
 
+# Validate .tool-versions file and python entry
+if [ ! -f "${WORK_DIR}/.tool-versions" ]; then
+  echo "❌ Missing .tool-versions file in project root" >&2
+  echo "   The Caylent devcontainer requires asdf to manage runtimes and tools" >&2
+  echo "   Create a .tool-versions file with: echo 'python 3.12.9' > .tool-versions" >&2
+  exit 1
+fi
+
+if ! grep -q "^python " "${WORK_DIR}/.tool-versions"; then
+  echo "❌ .tool-versions file must contain a python version entry" >&2
+  echo "   The Caylent devcontainer requires asdf to manage runtimes and tools" >&2
+  echo "   Add python to .tool-versions: echo 'python 3.12.9' >> .tool-versions" >&2
+  exit 1
+fi
+
+# Configure and log CICD environment
+CICD_VALUE="${CICD:-false}"
+if [ "$CICD_VALUE" = "true" ]; then
+  log_info "CICD environment variable: $CICD_VALUE"
+  log_info "Devcontainer configured to run in CICD mode (not a local dev environment)"
+else
+  log_info "CICD environment variable: ${CICD:-not set}"
+  log_info "Devcontainer configured to run as a local developer environment"
+fi
+echo "export CICD=${CICD_VALUE}" >> ${BASH_RC}
+echo "export CICD=${CICD_VALUE}" >> ${ZSH_RC}
+
 log_info "Starting post-create setup..."
 
 #########################
@@ -24,22 +51,26 @@ if [ -z "${DEFAULT_PYTHON_VERSION:-}" ]; then
   exit_with_error "❌ DEFAULT_PYTHON_VERSION is not set in the environment"
 fi
 
-AWS_CONFIG_ENABLED="${AWS_CONFIG_ENABLED:-true}"
-AWS_PROFILE_MAP_FILE="${WORK_DIR}/.devcontainer/aws-profile-map.json"
+if [ "$CICD_VALUE" != "true" ]; then
+  AWS_CONFIG_ENABLED="${AWS_CONFIG_ENABLED:-true}"
+  AWS_PROFILE_MAP_FILE="${WORK_DIR}/.devcontainer/aws-profile-map.json"
 
-if [ "${AWS_CONFIG_ENABLED,,}" = "true" ]; then
-  if [ ! -f "$AWS_PROFILE_MAP_FILE" ]; then
-    exit_with_error "❌ Missing AWS profile config: $AWS_PROFILE_MAP_FILE (required when AWS_CONFIG_ENABLED=true)"
-  fi
+  if [ "${AWS_CONFIG_ENABLED,,}" = "true" ]; then
+    if [ ! -f "$AWS_PROFILE_MAP_FILE" ]; then
+      exit_with_error "❌ Missing AWS profile config: $AWS_PROFILE_MAP_FILE (required when AWS_CONFIG_ENABLED=true)"
+    fi
 
-  AWS_PROFILE_MAP_JSON=$(<"$AWS_PROFILE_MAP_FILE")
+    AWS_PROFILE_MAP_JSON=$(<"$AWS_PROFILE_MAP_FILE")
 
-  if ! jq empty <<< "$AWS_PROFILE_MAP_JSON" >/dev/null 2>&1; then
-    log_error "$AWS_PROFILE_MAP_JSON"
-    exit_with_error "❌ AWS_PROFILE_MAP_JSON is not valid JSON"
+    if ! jq empty <<< "$AWS_PROFILE_MAP_JSON" >/dev/null 2>&1; then
+      log_error "$AWS_PROFILE_MAP_JSON"
+      exit_with_error "❌ AWS_PROFILE_MAP_JSON is not valid JSON"
+    fi
+  else
+    log_info "AWS configuration disabled (AWS_CONFIG_ENABLED=${AWS_CONFIG_ENABLED})"
   fi
 else
-  log_info "AWS configuration disabled (AWS_CONFIG_ENABLED=${AWS_CONFIG_ENABLED})"
+  log_info "CICD mode enabled - skipping AWS configuration validation"
 fi
 
 #################
@@ -48,8 +79,38 @@ fi
 log_info "Configuring ENV vars..."
 echo "export PATH=\"${WORK_DIR}/.localscripts:\${PATH}\"" >> ${BASH_RC}
 echo "export PATH=\"${WORK_DIR}/.localscripts:\${PATH}\"" >> ${ZSH_RC}
-echo "export DEVELOPER_NAME=${DEVELOPER_NAME}" >> ${BASH_RC}
-echo "export DEVELOPER_NAME=${DEVELOPER_NAME}" >> ${ZSH_RC}
+
+# Handle PAGER configuration by checking shell.env first
+SHELL_ENV_PAGER=""
+if [ -f "${WORK_DIR}/shell.env" ] && grep -q "^export PAGER=" "${WORK_DIR}/shell.env"; then
+  SHELL_ENV_PAGER=$(grep "^export PAGER=" "${WORK_DIR}/shell.env" | cut -d'=' -f2 | tr -d "'\"")
+  log_info "PAGER found in shell.env: ${SHELL_ENV_PAGER}"
+fi
+
+if [ -n "${SHELL_ENV_PAGER}" ]; then
+  PAGER_VALUE="${SHELL_ENV_PAGER}"
+  log_info "Using PAGER from shell.env: ${PAGER_VALUE}"
+else
+  PAGER_VALUE="cat"
+  log_info "PAGER not in shell.env, defaulting to: cat"
+fi
+
+# Force unset any existing PAGER and set our value
+unset PAGER 2>/dev/null || true
+export PAGER="${PAGER_VALUE}"
+log_info "PAGER configured as: ${PAGER_VALUE}"
+
+# Add to shell profiles with explicit unset first
+echo "# PAGER configuration from devcontainer" >> ${BASH_RC}
+echo "unset PAGER 2>/dev/null || true" >> ${BASH_RC}
+echo "export PAGER=${PAGER_VALUE}" >> ${BASH_RC}
+echo "# PAGER configuration from devcontainer" >> ${ZSH_RC}
+echo "unset PAGER 2>/dev/null || true" >> ${ZSH_RC}
+echo "export PAGER=${PAGER_VALUE}" >> ${ZSH_RC}
+if [ "$CICD_VALUE" != "true" ]; then
+  echo "export DEVELOPER_NAME=${DEVELOPER_NAME}" >> ${BASH_RC}
+  echo "export DEVELOPER_NAME=${DEVELOPER_NAME}" >> ${ZSH_RC}
+fi
 
 #################
 # Shell Aliases #
@@ -88,24 +149,32 @@ EOF
 #################
 # Configure AWS #
 #################
-if [ "${AWS_CONFIG_ENABLED,,}" = "true" ]; then
-  log_info "Configuring AWS profiles..."
-  mkdir -p /home/${CONTAINER_USER}/.aws
-  mkdir -p /home/${CONTAINER_USER}/.aws/amazonq/cache
-  chown -R ${CONTAINER_USER}:${CONTAINER_USER} /home/${CONTAINER_USER}/.aws/amazonq
+if [ "$CICD_VALUE" != "true" ]; then
+  if [ "${AWS_CONFIG_ENABLED,,}" = "true" ]; then
+    log_info "Configuring AWS profiles..."
+    mkdir -p /home/${CONTAINER_USER}/.aws
+    mkdir -p /home/${CONTAINER_USER}/.aws/amazonq/cache
+    chown -R ${CONTAINER_USER}:${CONTAINER_USER} /home/${CONTAINER_USER}/.aws/amazonq
 
-  jq -r 'to_entries[] |
-    "[profile \(.key)]\n" +
-    "sso_start_url = \(.value.sso_start_url)\n" +
-    "sso_region = \(.value.sso_region)\n" +
-    "sso_account_name = \(.value.account_name)\n" +
-    "sso_account_id = \(.value.account_id)\n" +
-    "sso_role_name = \(.value.role_name)\n" +
-    "region = \(.value.region)\n" +
-    "sso_auto_populated = true\n"' <<< "$AWS_PROFILE_MAP_JSON" \
-    > /home/${CONTAINER_USER}/.aws/config
+    AWS_OUTPUT_FORMAT="${AWS_DEFAULT_OUTPUT:-json}"
+    echo "export AWS_DEFAULT_OUTPUT=${AWS_OUTPUT_FORMAT}" >> ${BASH_RC}
+    echo "export AWS_DEFAULT_OUTPUT=${AWS_OUTPUT_FORMAT}" >> ${ZSH_RC}
+    jq -r 'to_entries[] |
+      "[profile \(.key)]\n" +
+      "sso_start_url = \(.value.sso_start_url)\n" +
+      "sso_region = \(.value.sso_region)\n" +
+      "sso_account_name = \(.value.account_name)\n" +
+      "sso_account_id = \(.value.account_id)\n" +
+      "sso_role_name = \(.value.role_name)\n" +
+      "region = \(.value.region)\n" +
+      "output = '"$AWS_OUTPUT_FORMAT"'\n" +
+      "sso_auto_populated = true\n"' <<< "$AWS_PROFILE_MAP_JSON" \
+      > /home/${CONTAINER_USER}/.aws/config
+  else
+    log_info "Skipping AWS profile configuration (AWS_CONFIG_ENABLED=${AWS_CONFIG_ENABLED})"
+  fi
 else
-  log_info "Skipping AWS profile configuration (AWS_CONFIG_ENABLED=${AWS_CONFIG_ENABLED})"
+  log_info "CICD mode enabled - skipping AWS profile configuration"
 fi
 
 #####################
@@ -113,7 +182,7 @@ fi
 #####################
 log_info "Installing core packages..."
 sudo apt-get update
-sudo apt-get install -y curl vim git jq yq nmap sipcalc wget unzip zip
+sudo apt-get install -y curl vim git gh jq yq nmap sipcalc wget unzip zip
 
 # Install Python build dependencies for asdf Python compilation
 log_info "Installing Python build dependencies..."
@@ -224,31 +293,55 @@ echo "export PATH=\"\$PATH:/home/${CONTAINER_USER}/.local/bin\"" >> ${BASH_RC}
 echo "export PATH=\"\$PATH:/home/${CONTAINER_USER}/.local/bin\"" >> ${ZSH_RC}
 
 log_info "Installing Python packages..."
-sudo -u ${CONTAINER_USER} bash -c "export PATH=\"\$PATH:/home/${CONTAINER_USER}/.local/bin\" && source /home/${CONTAINER_USER}/.asdf/asdf.sh && python -m pipx install aws-sso-util"
+if uname -r | grep -i microsoft > /dev/null; then
+  # WSL compatibility: Do not use sudo -u in WSL as it fails
+  python -m pipx install aws-sso-util --root-user-action=ignore
+else
+  # Non-WSL: Use sudo -u to ensure correct user environment
+  sudo -u ${CONTAINER_USER} bash -c "export PATH=\"\$PATH:/home/${CONTAINER_USER}/.local/bin\" && source /home/${CONTAINER_USER}/.asdf/asdf.sh && python -m pipx install aws-sso-util"
+fi
 python -m pip install ruamel_yaml --root-user-action=ignore
 
 #################
 # Configure Git #
 #################
-log_info "Setting up Git credentials..."
-cat <<EOF > /home/${CONTAINER_USER}/.netrc
+if [ "$CICD_VALUE" != "true" ]; then
+  log_info "Setting up Git credentials..."
+  cat <<EOF > /home/${CONTAINER_USER}/.netrc
 machine ${GIT_PROVIDER_URL}
 login ${GIT_USER}
 password ${GIT_TOKEN}
 EOF
-chmod 600 /home/${CONTAINER_USER}/.netrc
+  chmod 600 /home/${CONTAINER_USER}/.netrc
 
-cat <<EOF >> /home/${CONTAINER_USER}/.gitconfig
+  # Unset GIT_EDITOR to ensure vim is used
+  echo "unset GIT_EDITOR" >> ${BASH_RC}
+  echo "unset GIT_EDITOR" >> ${ZSH_RC}
+
+  cat <<EOF >> /home/${CONTAINER_USER}/.gitconfig
 [user]
     name = ${GIT_USER}
     email = ${GIT_USER_EMAIL}
+[core]
+    editor = vim
 [credential]
     credentialStore = cache
 [push]
     autoSetupRemote = true
 [safe]
     directory = *
+[pager]
+    branch = false
+    config = false
+    diff = false
+    log = false
+    show = false
+    status = false
+    tag = false
 EOF
+else
+  log_info "CICD mode enabled - skipping Git configuration"
+fi
 
 ###########
 # Cleanup #

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -80,6 +80,7 @@
   "userEnvProbe": "loginInteractiveShell",
   "containerEnv": {
     "AWS_CONFIG_ENABLED": "${localEnv:AWS_CONFIG_ENABLED}",
+    "CICD": "${localEnv:CICD}",
     "DEFAULT_GIT_BRANCH": "${localEnv:DEFAULT_GIT_BRANCH}",
     "DEFAULT_PYTHON_VERSION": "${localEnv:DEFAULT_PYTHON_VERSION}",
     "DEVELOPER_NAME": "${localEnv:DEVELOPER_NAME}",
@@ -88,7 +89,9 @@
     "GIT_PROVIDER_URL": "${localEnv:GIT_PROVIDER_URL}",
     "GIT_TOKEN": "${localEnv:GIT_TOKEN}",
     "GIT_USER": "${localEnv:GIT_USER}",
-    "GIT_USER_EMAIL": "${localEnv:GIT_USER_EMAIL}"
+    "GIT_USER_EMAIL": "${localEnv:GIT_USER_EMAIL}",
+    "PAGER": "${localEnv:PAGER}",
+    "AWS_DEFAULT_OUTPUT": "${localEnv:AWS_DEFAULT_OUTPUT}"
   },
-  "postCreateCommand": "sudo apt-get update; sudo apt-get install -y gettext-base jq; sudo bash .devcontainer/.devcontainer.postcreate.sh vscode"
+  "postCreateCommand": "bash -c 'if uname -r | grep -i microsoft > /dev/null; then sudo apt-get update && sudo apt-get install -y gettext-base jq && find .devcontainer -type f -exec sed -i \"s/\\r$//\" {} + && python3 .devcontainer/fix-line-endings.py && source shell.env && exec bash .devcontainer/.devcontainer.postcreate.sh vscode; else sudo apt-get update && sudo apt-get install -y gettext-base jq && sudo bash .devcontainer/.devcontainer.postcreate.sh vscode; fi'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -93,5 +93,5 @@
     "PAGER": "${localEnv:PAGER}",
     "AWS_DEFAULT_OUTPUT": "${localEnv:AWS_DEFAULT_OUTPUT}"
   },
-  "postCreateCommand": "bash -c 'if uname -r | grep -i microsoft > /dev/null; then sudo apt-get update && sudo apt-get install -y gettext-base jq && find .devcontainer -type f -exec sed -i \"s/\\r$//\" {} + && python3 .devcontainer/fix-line-endings.py && source shell.env && exec bash .devcontainer/.devcontainer.postcreate.sh vscode; else sudo apt-get update && sudo apt-get install -y gettext-base jq && sudo bash .devcontainer/.devcontainer.postcreate.sh vscode; fi'"
+  "postCreateCommand": "bash -c 'if uname -r | grep -i microsoft > /dev/null; then sudo apt-get update && sudo apt-get install -y gettext-base jq python3 && find .devcontainer -type f -exec sed -i \"s/\\r$//\" {} + && python3 .devcontainer/fix-line-endings.py && sudo apt-get remove -y python3 && sudo apt-get autoremove -y && source shell.env && exec bash .devcontainer/.devcontainer.postcreate.sh vscode; else sudo apt-get update && sudo apt-get install -y gettext-base jq && sudo bash .devcontainer/.devcontainer.postcreate.sh vscode; fi'"
 }

--- a/.devcontainer/example-container-env-values.json
+++ b/.devcontainer/example-container-env-values.json
@@ -8,6 +8,8 @@
     "GIT_PROVIDER_URL":       "github.com",
     "GIT_TOKEN":              "<Personal Access Token>",
     "GIT_USER":               "john.doe",
-    "GIT_USER_EMAIL":         "john.doe@caylent.com"
+    "GIT_USER_EMAIL":         "john.doe@caylent.com",
+    "PAGER":                  "cat",
+    "AWS_DEFAULT_OUTPUT":     "json"
   }
 }

--- a/.devcontainer/fix-line-endings.py
+++ b/.devcontainer/fix-line-endings.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Convert Windows line endings (CRLF) to Unix line endings (LF) for all text files.
+Excludes binary files and processes files in parallel for performance.
+"""
+
+import os
+import sys
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+
+# Thread-safe counters
+stats_lock = Lock()
+converted_count = 0
+skipped_count = 0
+error_count = 0
+
+def convert_file(file_path):
+    """Convert a single file from CRLF to LF if it's a text file."""
+    global converted_count, skipped_count, error_count
+    
+    try:
+        with open(file_path, 'rb') as f:
+            content = f.read()
+            
+        if not content:
+            with stats_lock:
+                skipped_count += 1
+            return False
+            
+        # Skip binary files (contain null bytes)
+        if b'\x00' in content:
+            with stats_lock:
+                skipped_count += 1
+            return False
+            
+        # Skip if no CRLF to convert
+        if b'\r\n' not in content:
+            with stats_lock:
+                skipped_count += 1
+            return False
+            
+        # Convert CRLF to LF
+        converted_content = content.replace(b'\r\n', b'\n')
+        
+        with open(file_path, 'wb') as f:
+            f.write(converted_content)
+            
+        with stats_lock:
+            converted_count += 1
+        return True
+        
+    except (OSError, IOError) as e:
+        with stats_lock:
+            error_count += 1
+        print(f"Error processing {file_path}: {e}", file=sys.stderr)
+        return False
+
+def main():
+    """Main function to process all files in the workspace."""
+    global converted_count, skipped_count, error_count
+    workspace_path = Path(os.getcwd())
+    
+    if not workspace_path.exists():
+        print(f"Error: Workspace path {workspace_path} does not exist", file=sys.stderr)
+        sys.exit(1)
+    
+    print(f"Converting line endings in: {workspace_path}")
+    
+    # Find all files
+    files_to_process = []
+    for root, dirs, files in os.walk(workspace_path):
+        # Skip .git directory for performance
+        if '.git' in dirs:
+            dirs.remove('.git')
+            
+        for file in files:
+            file_path = Path(root) / file
+            files_to_process.append(file_path)
+    
+    if not files_to_process:
+        print("No files found to process")
+        return
+    
+    print(f"Processing {len(files_to_process)} files...")
+    
+    # Process files in parallel
+    max_workers = os.cpu_count() or 1
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(convert_file, file_path): file_path 
+                  for file_path in files_to_process}
+        
+        for future in as_completed(futures):
+            try:
+                future.result()
+            except Exception as e:
+                file_path = futures[future]
+                print(f"Unexpected error processing {file_path}: {e}", file=sys.stderr)
+                with stats_lock:
+                    error_count += 1
+    
+    # Print summary
+    print(f"Line ending conversion complete:")
+    print(f"  Converted: {converted_count} files")
+    print(f"  Skipped: {skipped_count} files")
+    if error_count > 0:
+        print(f"  Errors: {error_count} files")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/.devcontainer/fix-line-endings.py
+++ b/.devcontainer/fix-line-endings.py
@@ -19,38 +19,38 @@ error_count = 0
 def convert_file(file_path):
     """Convert a single file from CRLF to LF if it's a text file."""
     global converted_count, skipped_count, error_count
-    
+
     try:
         with open(file_path, 'rb') as f:
             content = f.read()
-            
+
         if not content:
             with stats_lock:
                 skipped_count += 1
             return False
-            
+
         # Skip binary files (contain null bytes)
         if b'\x00' in content:
             with stats_lock:
                 skipped_count += 1
             return False
-            
+
         # Skip if no CRLF to convert
         if b'\r\n' not in content:
             with stats_lock:
                 skipped_count += 1
             return False
-            
+
         # Convert CRLF to LF
         converted_content = content.replace(b'\r\n', b'\n')
-        
+
         with open(file_path, 'wb') as f:
             f.write(converted_content)
-            
+
         with stats_lock:
             converted_count += 1
         return True
-        
+
     except (OSError, IOError) as e:
         with stats_lock:
             error_count += 1
@@ -61,36 +61,36 @@ def main():
     """Main function to process all files in the workspace."""
     global converted_count, skipped_count, error_count
     workspace_path = Path(os.getcwd())
-    
+
     if not workspace_path.exists():
         print(f"Error: Workspace path {workspace_path} does not exist", file=sys.stderr)
         sys.exit(1)
-    
+
     print(f"Converting line endings in: {workspace_path}")
-    
+
     # Find all files
     files_to_process = []
     for root, dirs, files in os.walk(workspace_path):
         # Skip .git directory for performance
         if '.git' in dirs:
             dirs.remove('.git')
-            
+
         for file in files:
             file_path = Path(root) / file
             files_to_process.append(file_path)
-    
+
     if not files_to_process:
         print("No files found to process")
         return
-    
+
     print(f"Processing {len(files_to_process)} files...")
-    
+
     # Process files in parallel
     max_workers = os.cpu_count() or 1
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = {executor.submit(convert_file, file_path): file_path 
+        futures = {executor.submit(convert_file, file_path): file_path
                   for file_path in files_to_process}
-        
+
         for future in as_completed(futures):
             try:
                 future.result()
@@ -99,7 +99,7 @@ def main():
                 print(f"Unexpected error processing {file_path}: {e}", file=sys.stderr)
                 with stats_lock:
                     error_count += 1
-    
+
     # Print summary
     print(f"Line ending conversion complete:")
     print(f"  Converted: {converted_count} files")

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This repository provides the **base development container** configuration used a
 - 🔐 **Secure and configurable**: injects secrets via environment, not committed
 - 🧩 **Smart defaults**: tools, AWS profiles, aliases, Python setup, Git config, and more
 - 🧪 **Consistent environments**: ensures identical local dev setups across teams using `asdf` to pin and manage exact binary versions
+- 🚀 **CI/CD ready**: supports automated environments with `CICD=true` flag
+- 📝 **Windows line ending support**: automatically converts CRLF to LF on WSL for compatibility
 
 📦 Repo URL: [`https://github.com/caylent-solutions/devcontainer`](https://github.com/caylent-solutions/devcontainer)
 
@@ -37,6 +39,7 @@ This repository provides the **base development container** configuration used a
 
 - `devcontainer.json` — VS Code container definition
 - `.devcontainer.postcreate.sh` — container setup script
+- `fix-line-endings.py` — automatic Windows line ending conversion for WSL compatibility
 - `cdevcontainer` — Caylent Devcontainer CLI tool for environment management
 - `example-aws-profile-map.json` — declarative AWS SSO profile config template
 - Git, AWS CLI, Docker, Python, `asdf`, aliases, shell profile injection
@@ -71,6 +74,14 @@ These extensions are auto-installed on container start and work with both VS Cod
 - [VS Code](https://code.visualstudio.com/Download) or [Cursor](https://cursor.sh/)
 - Python 3.12.9 - [Installation Guide](supplemental-docs/PYTHON_INSTALL.md#for-windows-using-windows-store-or-official-installer)
 
+> ⚠️ **Important for Windows users**: When cloning Git repositories that will use this devcontainer, ensure Git is configured to use Unix line endings (LF) instead of Windows line endings (CRLF). Configure this globally with:
+> ```bash
+> git config --global core.autocrlf false
+> git config --global core.eol lf
+> ```
+> 
+> This prevents issues with shell scripts and other text files when running in WSL environments. The devcontainer includes automatic line ending conversion for WSL compatibility.
+
 ### IDE Command Line Setup
 
 The `cdevcontainer` CLI requires IDE command-line tools to launch projects. Enable them as follows:
@@ -95,22 +106,27 @@ The `cdevcontainer` CLI requires IDE command-line tools to launch projects. Enab
 
 ### 1. Install the CLI Tool
 
-First, install the Caylent Devcontainer CLI:
+First, install the Caylent Devcontainer CLI using pipx (recommended to avoid package conflicts):
 
 ```bash
-pip install caylent-devcontainer-cli
+pipx install caylent-devcontainer-cli
 ```
 
 You can also install a specific version:
 
 ```bash
-pip install caylent-devcontainer-cli==1.1.0
+pipx install caylent-devcontainer-cli==1.1.0
 ```
 
 To install directly from GitHub (alternative method):
 
 ```bash
-pip install git+https://github.com/caylent-solutions/devcontainer.git@1.1.0#subdirectory=caylent-devcontainer-cli
+pipx install git+https://github.com/caylent-solutions/devcontainer.git@1.1.0#subdirectory=caylent-devcontainer-cli
+```
+
+If you don't have pipx installed, install it first:
+```bash
+python -m pip install pipx
 ```
 
 After installation, you can run the CLI from anywhere:
@@ -158,6 +174,8 @@ When running `cdevcontainer setup-devcontainer`, you'll be guided through config
 - Python version
 - Developer information
 - Extra Ubuntu packages
+- Pager selection (cat, less, more, most)
+- AWS CLI output format (json, table, text, yaml) - only if AWS is enabled
 
 The interactive setup will create a `devcontainer-environment-variables.json` file with your settings.
 
@@ -174,6 +192,8 @@ Then edit `devcontainer-environment-variables.json` with your values:
 - Git credentials: `GIT_USER`, `GIT_USER_EMAIL`, `GIT_TOKEN`
 - AWS SSO and account information (required if `AWS_CONFIG_ENABLED=true`)
 - Extra Ubuntu LTS packages: `EXTRA_APT_PACKAGES`
+- `PAGER` (default: `cat`) - Choose from: cat, less, more, most
+- `AWS_DEFAULT_OUTPUT` (default: `json`) - Choose from: json, table, text, yaml
 
 #### Client/Project Templates
 
@@ -332,6 +352,58 @@ cdevcontainer code -y
 
 ---
 
+## 🚀 CI/CD Support
+
+The devcontainer supports running in CI/CD environments where developer-specific configurations (Git credentials, AWS profiles, developer names) are not needed or are handled separately.
+
+To enable CI/CD mode, set the `CICD` environment variable to `true`:
+
+```bash
+export CICD=true
+```
+
+When `CICD=true`, the devcontainer will skip:
+- AWS configuration validation and setup
+- Git credential configuration
+- Developer name environment variable setup
+- AWS profile creation
+
+This allows the devcontainer to run in automated environments where:
+- Git authentication is handled by the CI/CD system
+- AWS credentials are provided through IAM roles or other mechanisms
+- Developer-specific personalization is not required
+
+### Required Environment Variables for CI/CD
+
+When running in CI/CD mode, you still need to set these core environment variables:
+
+```yaml
+# GitHub Actions example
+env:
+  CICD: "true"                           # Enable CI/CD mode
+  DEFAULT_GIT_BRANCH: "main"              # Required: Git branch for aliases
+  DEFAULT_PYTHON_VERSION: "3.12.9"        # Required: Python version to install
+  EXTRA_APT_PACKAGES: ""                  # Optional: Additional Ubuntu packages
+  PAGER: "cat"                            # Optional: Pager for command output (defaults to cat)
+  AWS_DEFAULT_OUTPUT: "json"              # Optional: AWS CLI output format (defaults to json)
+```
+
+### Environment Variables Skipped in CI/CD Mode
+
+These variables are not needed when `CICD=true` as they're handled by the CI/CD system:
+
+```yaml
+# These are SKIPPED in CI/CD mode - do not set them
+# AWS_CONFIG_ENABLED: "true"             # Skipped: AWS handled by CI/CD
+# DEVELOPER_NAME: "johndoe"              # Skipped: Not needed in CI/CD
+# GIT_PROVIDER_URL: "github.com"         # Skipped: Git handled by CI/CD
+# GIT_TOKEN: "<token>"                   # Skipped: Git handled by CI/CD
+# GIT_USER: "john.doe"                   # Skipped: Git handled by CI/CD
+# GIT_USER_EMAIL: "john.doe@example.com" # Skipped: Git handled by CI/CD
+```
+
+---
+
 ## 🧩 Post-Launch Setup
 
 ### 🧠 GitHub Copilot
@@ -380,6 +452,8 @@ Or open the Source Control tab in your IDE to confirm the repo is accessible.
 ```json
 "DEFAULT_PYTHON_VERSION": "3.12.9"
 ```
+
+> ✅ **Automatic .tool-versions creation**: The setup command will automatically check for a `.tool-versions` file in your project root. If not found, it will create one with your chosen Python version to ensure consistent runtime management via asdf.
 
 > ✅ Best practice: commit `.tool-versions` to your repo:
 ```bash
@@ -447,6 +521,7 @@ JetBrains IDEs (like PyCharm) support Devcontainers via [JetBrains Gateway](http
 |------|---------|
 | `.devcontainer/devcontainer.json` | VS Code container setup |
 | `.devcontainer/.devcontainer.postcreate.sh` | Container provisioning logic |
+| `.devcontainer/fix-line-endings.py` | Windows line ending conversion for WSL compatibility |
 | `.devcontainer/example-aws-profile-map.json` | AWS profile template |
 | `.devcontainer/aws-profile-map.json` | Your active AWS profiles |
 | `.devcontainer/example-container-env-values.json` | Developer config example |

--- a/README.md
+++ b/README.md
@@ -584,6 +584,11 @@ cdevcontainer --help
 # Set up a devcontainer in a project directory
 cdevcontainer setup-devcontainer /path/to/your/project
 
+# Set up with specific git reference (branch, tag, or commit)
+cdevcontainer setup-devcontainer --ref main /path/to/your/project
+cdevcontainer setup-devcontainer --ref 1.0.0 /path/to/your/project
+cdevcontainer setup-devcontainer --ref feature/new-feature /path/to/your/project
+
 # Launch IDE with the devcontainer environment (default: VS Code)
 cdevcontainer code [/path/to/your/project]
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ These extensions are auto-installed on container start and work with both VS Cod
 > git config --global core.autocrlf false
 > git config --global core.eol lf
 > ```
-> 
+>
 > This prevents issues with shell scripts and other text files when running in WSL environments. The devcontainer includes automatic line ending conversion for WSL compatibility.
 
 ### IDE Command Line Setup

--- a/caylent-devcontainer-cli/MANUAL_TESTING.md
+++ b/caylent-devcontainer-cli/MANUAL_TESTING.md
@@ -161,6 +161,44 @@ cat .tool-versions
 # Should still contain: python 3.11.5
 ```
 
+### 7. Git Reference Override Test
+
+**Purpose**: Verify the --ref flag works with different git references
+
+```bash
+# Test 1: Use main branch instead of CLI version
+mkdir -p /tmp/test-ref-main
+cd /tmp/test-ref-main
+
+# Run setup with main branch
+cdevcontainer setup-devcontainer --ref main --manual .
+# Should clone from main branch instead of CLI version tag
+
+# Verify files were created
+ls -la .devcontainer/
+# Should see devcontainer files
+
+# Test 2: Use specific tag
+mkdir -p /tmp/test-ref-tag
+cd /tmp/test-ref-tag
+
+# Run setup with specific tag (use a known existing tag)
+cdevcontainer setup-devcontainer --ref 1.0.0 --manual .
+# Should clone from the specified tag
+
+# Verify files were created
+ls -la .devcontainer/
+# Should see devcontainer files
+
+# Test 3: Invalid reference should fail gracefully
+mkdir -p /tmp/test-ref-invalid
+cd /tmp/test-ref-invalid
+
+# Run setup with invalid reference
+cdevcontainer setup-devcontainer --ref nonexistent-branch --manual .
+# Should fail with clear error message about the reference not existing
+```
+
 ## Reporting Issues
 
 If any test fails:

--- a/caylent-devcontainer-cli/MANUAL_TESTING.md
+++ b/caylent-devcontainer-cli/MANUAL_TESTING.md
@@ -53,11 +53,14 @@ cdevcontainer setup-devcontainer .
 # - Git token: test-token
 # - Extra packages: (leave empty)
 # - Don't save as template
+# - Press any key when prompted to create .tool-versions file
 
 # Verify files were created
 ls -la .devcontainer/
 cat devcontainer-environment-variables.json
 # Should see the values you entered
+cat .tool-versions
+# Should contain: python 3.12.9
 ```
 
 ### 3. Template Save and Load Workflow
@@ -118,9 +121,44 @@ cdevcontainer setup-devcontainer .
 # Follow prompts, but this time set:
 # - AWS_CONFIG_ENABLED: true
 # - Add a simple AWS profile configuration
+# - Press any key when prompted to create .tool-versions file
 
 # Verify AWS profile map was created
 cat .devcontainer/aws-profile-map.json
+# Verify .tool-versions was created
+cat .tool-versions
+```
+
+### 6. .tool-versions File Management Test
+
+**Purpose**: Verify .tool-versions file detection and creation
+
+```bash
+# Test 1: Project without .tool-versions
+mkdir -p /tmp/test-no-tool-versions
+cd /tmp/test-no-tool-versions
+
+# Run setup (manual mode for simplicity)
+cdevcontainer setup-devcontainer --manual .
+# Should prompt to create .tool-versions file
+# Press any key to create it
+
+# Verify file was created with correct content
+cat .tool-versions
+# Should contain: python 3.12.9
+
+# Test 2: Project with existing .tool-versions
+mkdir -p /tmp/test-existing-tool-versions
+cd /tmp/test-existing-tool-versions
+echo "python 3.11.5" > .tool-versions
+
+# Run setup
+cdevcontainer setup-devcontainer --manual .
+# Should detect existing file and not prompt to create
+
+# Verify original content preserved
+cat .tool-versions
+# Should still contain: python 3.11.5
 ```
 
 ## Reporting Issues

--- a/caylent-devcontainer-cli/MANUAL_TESTING.md
+++ b/caylent-devcontainer-cli/MANUAL_TESTING.md
@@ -53,7 +53,7 @@ cdevcontainer setup-devcontainer .
 # - Git token: test-token
 # - Extra packages: (leave empty)
 # - Don't save as template
-# - Press any key when prompted to create .tool-versions file
+# - Press Enter when prompted to create .tool-versions file
 
 # Verify files were created
 ls -la .devcontainer/
@@ -121,7 +121,7 @@ cdevcontainer setup-devcontainer .
 # Follow prompts, but this time set:
 # - AWS_CONFIG_ENABLED: true
 # - Add a simple AWS profile configuration
-# - Press any key when prompted to create .tool-versions file
+# - Press Enter when prompted to create .tool-versions file
 
 # Verify AWS profile map was created
 cat .devcontainer/aws-profile-map.json
@@ -141,7 +141,7 @@ cd /tmp/test-no-tool-versions
 # Run setup (manual mode for simplicity)
 cdevcontainer setup-devcontainer --manual .
 # Should prompt to create .tool-versions file
-# Press any key to create it
+# Press Enter to create it
 
 # Verify file was created with correct content
 cat .tool-versions

--- a/caylent-devcontainer-cli/README.md
+++ b/caylent-devcontainer-cli/README.md
@@ -78,6 +78,11 @@ cdevcontainer setup-devcontainer --manual /path/to/your/project
 
 # Update existing devcontainer files to the current CLI version
 cdevcontainer setup-devcontainer --update /path/to/your/project
+
+# Use specific git reference (branch, tag, or commit) instead of CLI version
+cdevcontainer setup-devcontainer --ref main /path/to/your/project
+cdevcontainer setup-devcontainer --ref 1.0.0 /path/to/your/project
+cdevcontainer setup-devcontainer --ref feature/new-feature /path/to/your/project
 ```
 
 The interactive setup will guide you through:

--- a/caylent-devcontainer-cli/README.md
+++ b/caylent-devcontainer-cli/README.md
@@ -42,11 +42,14 @@ The CLI requires IDE command-line tools to launch projects:
 ### Install CLI
 
 ```bash
-# Install from PyPI (when available)
-pip install caylent-devcontainer-cli
+# Install from PyPI using pipx (recommended to avoid package conflicts)
+pipx install caylent-devcontainer-cli
 
 # Install from GitHub with a specific version tag
-pip install git+https://github.com/caylent-solutions/devcontainer.git@0.1.0#subdirectory=caylent-devcontainer-cli
+pipx install git+https://github.com/caylent-solutions/devcontainer.git@0.1.0#subdirectory=caylent-devcontainer-cli
+
+# If you don't have pipx installed, install it first:
+python -m pip install pipx
 ```
 
 ## Usage
@@ -80,7 +83,10 @@ cdevcontainer setup-devcontainer --update /path/to/your/project
 The interactive setup will guide you through:
 1. Using an existing template or creating a new one
 2. Configuring environment variables
-3. Setting up AWS profiles (if enabled)
+3. Selecting pager preference (cat, less, more, most)
+4. Setting up AWS profiles (if enabled)
+5. Selecting AWS CLI output format (json, table, text, yaml) - only if AWS is enabled
+6. Automatically creating a `.tool-versions` file if one doesn't exist to ensure consistent runtime management via asdf
 
 ### Managing Templates
 

--- a/caylent-devcontainer-cli/src/caylent_devcontainer_cli/commands/setup.py
+++ b/caylent-devcontainer-cli/src/caylent_devcontainer_cli/commands/setup.py
@@ -155,7 +155,7 @@ def check_and_create_tool_versions(target_path: str, python_version: str) -> Non
     print(f"With content:\n{file_content}")
 
     try:
-        input("Press any key to create the file...")
+        input("Press Enter to create the file...")
     except (EOFError, KeyboardInterrupt):
         # Handle non-interactive environments (like tests) or user cancellation
         pass

--- a/caylent-devcontainer-cli/tests/functional/test_pager_aws_output.py
+++ b/caylent-devcontainer-cli/tests/functional/test_pager_aws_output.py
@@ -1,0 +1,184 @@
+"""Functional tests for pager and AWS output format selection features."""
+
+import json
+import os
+import subprocess
+import tempfile
+
+
+def run_command(cmd, cwd=None, input_text=None):
+    """Run a command and return the output."""
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        input=input_text.encode() if input_text else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result
+
+
+def test_env_export_includes_pager_and_aws_output():
+    """Test that env export includes PAGER and AWS_DEFAULT_OUTPUT variables."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create a test environment file with the new variables
+        env_file = os.path.join(temp_dir, "test-env.json")
+        env_data = {
+            "containerEnv": {
+                "AWS_CONFIG_ENABLED": "true",
+                "DEFAULT_GIT_BRANCH": "main",
+                "DEFAULT_PYTHON_VERSION": "3.12.9",
+                "DEVELOPER_NAME": "testuser",
+                "GIT_PROVIDER_URL": "github.com",
+                "GIT_TOKEN": "test-token",
+                "GIT_USER": "testuser",
+                "GIT_USER_EMAIL": "test@example.com",
+                "EXTRA_APT_PACKAGES": "",
+                "PAGER": "less",
+                "AWS_DEFAULT_OUTPUT": "table",
+            }
+        }
+
+        with open(env_file, "w") as f:
+            json.dump(env_data, f, indent=2)
+
+        # Test env export command
+        output_file = os.path.join(temp_dir, "output.sh")
+        result = run_command(["cdevcontainer", "env", "export", env_file, "-o", output_file, "-y"])
+
+        assert result.returncode == 0
+
+        # Check that the output file contains the new variables
+        with open(output_file, "r") as f:
+            content = f.read()
+
+        assert "export PAGER='less'" in content
+        assert "export AWS_DEFAULT_OUTPUT='table'" in content
+
+
+def test_env_export_with_default_values():
+    """Test that env export works with default values for new variables."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create a test environment file without the new variables
+        env_file = os.path.join(temp_dir, "test-env.json")
+        env_data = {
+            "containerEnv": {
+                "AWS_CONFIG_ENABLED": "true",
+                "DEFAULT_GIT_BRANCH": "main",
+                "DEFAULT_PYTHON_VERSION": "3.12.9",
+                "DEVELOPER_NAME": "testuser",
+                "GIT_PROVIDER_URL": "github.com",
+                "GIT_TOKEN": "test-token",
+                "GIT_USER": "testuser",
+                "GIT_USER_EMAIL": "test@example.com",
+                "EXTRA_APT_PACKAGES": "",
+            }
+        }
+
+        with open(env_file, "w") as f:
+            json.dump(env_data, f, indent=2)
+
+        # Test env export command
+        output_file = os.path.join(temp_dir, "output.sh")
+        result = run_command(["cdevcontainer", "env", "export", env_file, "-o", output_file, "-y"])
+
+        assert result.returncode == 0
+
+        # The command should succeed even without the new variables
+        assert os.path.exists(output_file)
+
+
+def test_env_export_pager_options():
+    """Test that all pager options work correctly in env export."""
+    pager_options = ["cat", "less", "more", "most"]
+
+    for pager in pager_options:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_file = os.path.join(temp_dir, "test-env.json")
+            env_data = {
+                "containerEnv": {
+                    "AWS_CONFIG_ENABLED": "false",
+                    "DEFAULT_GIT_BRANCH": "main",
+                    "DEFAULT_PYTHON_VERSION": "3.12.9",
+                    "DEVELOPER_NAME": "testuser",
+                    "GIT_PROVIDER_URL": "github.com",
+                    "GIT_TOKEN": "test-token",
+                    "GIT_USER": "testuser",
+                    "GIT_USER_EMAIL": "test@example.com",
+                    "EXTRA_APT_PACKAGES": "",
+                    "PAGER": pager,
+                }
+            }
+
+            with open(env_file, "w") as f:
+                json.dump(env_data, f, indent=2)
+
+            output_file = os.path.join(temp_dir, "output.sh")
+            result = run_command(["cdevcontainer", "env", "export", env_file, "-o", output_file, "-y"])
+
+            assert result.returncode == 0
+
+            with open(output_file, "r") as f:
+                content = f.read()
+
+            assert f"export PAGER='{pager}'" in content
+
+
+def test_env_export_aws_output_options():
+    """Test that all AWS output format options work correctly in env export."""
+    aws_output_options = ["json", "table", "text", "yaml"]
+
+    for output_format in aws_output_options:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_file = os.path.join(temp_dir, "test-env.json")
+            env_data = {
+                "containerEnv": {
+                    "AWS_CONFIG_ENABLED": "true",
+                    "DEFAULT_GIT_BRANCH": "main",
+                    "DEFAULT_PYTHON_VERSION": "3.12.9",
+                    "DEVELOPER_NAME": "testuser",
+                    "GIT_PROVIDER_URL": "github.com",
+                    "GIT_TOKEN": "test-token",
+                    "GIT_USER": "testuser",
+                    "GIT_USER_EMAIL": "test@example.com",
+                    "EXTRA_APT_PACKAGES": "",
+                    "PAGER": "cat",
+                    "AWS_DEFAULT_OUTPUT": output_format,
+                }
+            }
+
+            with open(env_file, "w") as f:
+                json.dump(env_data, f, indent=2)
+
+            output_file = os.path.join(temp_dir, "output.sh")
+            result = run_command(["cdevcontainer", "env", "export", env_file, "-o", output_file, "-y"])
+
+            assert result.returncode == 0
+
+            with open(output_file, "r") as f:
+                content = f.read()
+
+            assert f"export AWS_DEFAULT_OUTPUT='{output_format}'" in content
+
+
+def test_setup_manual_includes_new_variables():
+    """Test that manual setup creates example files with new variables."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = run_command(["cdevcontainer", "setup-devcontainer", "--manual", temp_dir])
+
+        assert result.returncode == 0
+
+        # Check that the example file includes the new variables
+        example_file = os.path.join(temp_dir, ".devcontainer", "example-container-env-values.json")
+        assert os.path.exists(example_file)
+
+        with open(example_file, "r") as f:
+            example_data = json.load(f)
+
+        # The example file should show the structure that includes these variables
+        # (even if they're not set by default in the example)
+        container_env = example_data.get("containerEnv", {})
+
+        # At minimum, the structure should be compatible with the new variables
+        assert isinstance(container_env, dict)

--- a/caylent-devcontainer-cli/tests/functional/test_pager_aws_output_fixed.py
+++ b/caylent-devcontainer-cli/tests/functional/test_pager_aws_output_fixed.py
@@ -1,0 +1,115 @@
+"""Functional tests for pager and AWS output format selection features."""
+
+import json
+import os
+import subprocess
+import tempfile
+
+
+def run_command(cmd, cwd=None, input_text=None):
+    """Run a command and return the output."""
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        input=input_text.encode() if input_text else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result
+
+
+def test_env_export_includes_pager_and_aws_output():
+    """Test that env export includes PAGER and AWS_DEFAULT_OUTPUT variables."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create a test environment file with the new variables
+        env_file = os.path.join(temp_dir, "test-env.json")
+        env_data = {
+            "containerEnv": {
+                "AWS_CONFIG_ENABLED": "true",
+                "DEFAULT_GIT_BRANCH": "main",
+                "DEFAULT_PYTHON_VERSION": "3.12.9",
+                "DEVELOPER_NAME": "testuser",
+                "GIT_PROVIDER_URL": "github.com",
+                "GIT_TOKEN": "test-token",
+                "GIT_USER": "testuser",
+                "GIT_USER_EMAIL": "test@example.com",
+                "EXTRA_APT_PACKAGES": "",
+                "PAGER": "less",
+                "AWS_DEFAULT_OUTPUT": "table",
+            }
+        }
+
+        with open(env_file, "w") as f:
+            json.dump(env_data, f, indent=2)
+
+        # Test env export command with -y flag to bypass confirmation
+        output_file = os.path.join(temp_dir, "output.sh")
+        result = run_command(["cdevcontainer", "env", "export", env_file, "-o", output_file, "-y"])
+
+        assert result.returncode == 0
+
+        # Check that the output file contains the new variables
+        with open(output_file, "r") as f:
+            content = f.read()
+
+        assert "export PAGER='less'" in content
+        assert "export AWS_DEFAULT_OUTPUT='table'" in content
+
+
+def test_env_export_pager_options():
+    """Test that all pager options work correctly in env export."""
+    pager_options = ["cat", "less", "more", "most"]
+
+    for pager in pager_options:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_file = os.path.join(temp_dir, "test-env.json")
+            env_data = {
+                "containerEnv": {
+                    "AWS_CONFIG_ENABLED": "false",
+                    "DEFAULT_GIT_BRANCH": "main",
+                    "DEFAULT_PYTHON_VERSION": "3.12.9",
+                    "DEVELOPER_NAME": "testuser",
+                    "GIT_PROVIDER_URL": "github.com",
+                    "GIT_TOKEN": "test-token",
+                    "GIT_USER": "testuser",
+                    "GIT_USER_EMAIL": "test@example.com",
+                    "EXTRA_APT_PACKAGES": "",
+                    "PAGER": pager,
+                }
+            }
+
+            with open(env_file, "w") as f:
+                json.dump(env_data, f, indent=2)
+
+            output_file = os.path.join(temp_dir, "output.sh")
+            result = run_command(["cdevcontainer", "env", "export", env_file, "-o", output_file, "-y"])
+
+            assert result.returncode == 0
+
+            with open(output_file, "r") as f:
+                content = f.read()
+
+            assert f"export PAGER='{pager}'" in content
+
+
+def test_setup_manual_includes_new_variables():
+    """Test that manual setup creates example files with new variables."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = run_command(["cdevcontainer", "setup-devcontainer", "--manual", temp_dir])
+
+        assert result.returncode == 0
+
+        # Check that the example file includes the new variables
+        example_file = os.path.join(temp_dir, ".devcontainer", "example-container-env-values.json")
+        assert os.path.exists(example_file)
+
+        with open(example_file, "r") as f:
+            example_data = json.load(f)
+
+        # The example file should be valid JSON with containerEnv structure
+        container_env = example_data.get("containerEnv", {})
+
+        # At minimum, the structure should be compatible with the new variables
+        assert isinstance(container_env, dict)
+        assert len(container_env) > 0  # Should have some environment variables

--- a/caylent-devcontainer-cli/tests/unit/test_apply_template.py
+++ b/caylent-devcontainer-cli/tests/unit/test_apply_template.py
@@ -15,13 +15,16 @@ def test_apply_template_with_container_env():
         "containerEnv": {
             "AWS_CONFIG_ENABLED": "true",
             "DEFAULT_GIT_BRANCH": "main",
+            "DEFAULT_PYTHON_VERSION": "3.12.9",
         },
         "aws_profile_map": {"default": {"region": "us-west-2"}},
     }
 
     with patch("os.path.exists", return_value=False), patch("shutil.copytree"), patch("shutil.rmtree"), patch(
         "builtins.open"
-    ), patch("json.dump"), patch("os.remove"):
+    ), patch("json.dump"), patch("os.remove"), patch(
+        "caylent_devcontainer_cli.commands.setup.check_and_create_tool_versions"
+    ):
         apply_template(template_data, "/target/path", "/source/path")
 
 
@@ -31,13 +34,16 @@ def test_apply_template_with_env_values():
         "env_values": {
             "AWS_CONFIG_ENABLED": "true",
             "DEFAULT_GIT_BRANCH": "main",
+            "DEFAULT_PYTHON_VERSION": "3.12.9",
         },
         "aws_profile_map": {"default": {"region": "us-west-2"}},
     }
 
     with patch("os.path.exists", return_value=False), patch("shutil.copytree"), patch("shutil.rmtree"), patch(
         "builtins.open"
-    ), patch("json.dump"), patch("os.remove"):
+    ), patch("json.dump"), patch("os.remove"), patch(
+        "caylent_devcontainer_cli.commands.setup.check_and_create_tool_versions"
+    ):
         apply_template(template_data, "/target/path", "/source/path")
 
 

--- a/caylent-devcontainer-cli/tests/unit/test_json_newlines.py
+++ b/caylent-devcontainer-cli/tests/unit/test_json_newlines.py
@@ -14,11 +14,12 @@ from caylent_devcontainer_cli.commands.setup_interactive import apply_template, 
 @patch("builtins.open", new_callable=mock_open)
 def test_apply_template_adds_newlines(mock_file, mock_copytree, mock_exists):
     template_data = {
-        "env_values": {"AWS_CONFIG_ENABLED": "true"},
+        "env_values": {"AWS_CONFIG_ENABLED": "true", "DEFAULT_PYTHON_VERSION": "3.12.9"},
         "aws_profile_map": {"default": {"region": "us-west-2"}},
     }
 
-    apply_template(template_data, "/target", "/source")
+    with patch("caylent_devcontainer_cli.commands.setup.check_and_create_tool_versions"):
+        apply_template(template_data, "/target", "/source")
 
     # Check that write was called with a newline for both files
     write_calls = mock_file().write.call_args_list

--- a/caylent-devcontainer-cli/tests/unit/test_pager_aws_output.py
+++ b/caylent-devcontainer-cli/tests/unit/test_pager_aws_output.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Tests for pager and AWS output format selection features."""
+
+import os
+import sys
+from unittest.mock import patch
+
+# Add the parent directory to the path so we can import the CLI module
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+import pytest
+
+
+@patch("questionary.password")
+@patch("questionary.text")
+@patch("questionary.select")
+def test_prompt_env_values_none_pager(mock_select, mock_text, mock_password):
+    """Test prompt_env_values with None response for pager selection."""
+    from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
+
+    mock_select.return_value.ask.side_effect = ["true", None]
+    mock_text.return_value.ask.side_effect = [
+        "main",
+        "3.12.9",
+        "Developer",
+        "github.com",
+        "user",
+        "user@example.com",
+        "",
+    ]
+    mock_password.return_value.ask.return_value = "token123"
+
+    with pytest.raises(SystemExit):
+        prompt_env_values()
+
+
+@patch("questionary.password")
+@patch("questionary.text")
+@patch("questionary.select")
+def test_prompt_env_values_none_aws_output(mock_select, mock_text, mock_password):
+    """Test prompt_env_values with None response for AWS output format."""
+    from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
+
+    mock_select.return_value.ask.side_effect = ["true", "cat", None]
+    mock_text.return_value.ask.side_effect = [
+        "main",
+        "3.12.9",
+        "Developer",
+        "github.com",
+        "user",
+        "user@example.com",
+        "",
+    ]
+    mock_password.return_value.ask.return_value = "token123"
+
+    with pytest.raises(SystemExit):
+        prompt_env_values()
+
+
+@patch("questionary.password")
+@patch("questionary.text")
+@patch("questionary.select")
+def test_pager_selection_options(mock_select, mock_text, mock_password):
+    """Test that all pager options are available and work correctly."""
+    from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
+
+    pager_options = ["cat", "less", "more", "most"]
+
+    for pager in pager_options:
+        mock_select.return_value.ask.side_effect = ["false", pager]
+        mock_text.return_value.ask.side_effect = [
+            "main",
+            "3.12.9",
+            "Developer",
+            "github.com",
+            "user",
+            "user@example.com",
+            "",
+        ]
+        mock_password.return_value.ask.return_value = "token123"
+
+        result = prompt_env_values()
+        assert result["PAGER"] == pager
+
+
+@patch("questionary.password")
+@patch("questionary.text")
+@patch("questionary.select")
+def test_aws_output_selection_options(mock_select, mock_text, mock_password):
+    """Test that all AWS output format options are available and work correctly."""
+    from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
+
+    aws_output_options = ["json", "table", "text", "yaml"]
+
+    for output_format in aws_output_options:
+        mock_select.return_value.ask.side_effect = ["true", "cat", output_format]
+        mock_text.return_value.ask.side_effect = [
+            "main",
+            "3.12.9",
+            "Developer",
+            "github.com",
+            "user",
+            "user@example.com",
+            "",
+        ]
+        mock_password.return_value.ask.return_value = "token123"
+
+        result = prompt_env_values()
+        assert result["AWS_DEFAULT_OUTPUT"] == output_format
+
+
+@patch("questionary.password")
+@patch("questionary.text")
+@patch("questionary.select")
+def test_aws_output_not_prompted_when_aws_disabled(mock_select, mock_text, mock_password):
+    """Test that AWS output format is not prompted when AWS is disabled."""
+    from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
+
+    # Only two select calls: AWS config (false) and pager (cat)
+    mock_select.return_value.ask.side_effect = ["false", "cat"]
+    mock_text.return_value.ask.side_effect = [
+        "main",
+        "3.12.9",
+        "Developer",
+        "github.com",
+        "user",
+        "user@example.com",
+        "",
+    ]
+    mock_password.return_value.ask.return_value = "token123"
+
+    result = prompt_env_values()
+
+    assert result["AWS_CONFIG_ENABLED"] == "false"
+    assert result["PAGER"] == "cat"
+    assert "AWS_DEFAULT_OUTPUT" not in result
+
+    # Verify that select was only called twice (AWS config and pager)
+    assert mock_select.return_value.ask.call_count == 2
+
+
+@patch("questionary.password")
+@patch("questionary.text")
+@patch("questionary.select")
+def test_default_values_selection(mock_select, mock_text, mock_password):
+    """Test that default values are properly set for pager and AWS output."""
+    from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
+
+    # Test with AWS enabled - should get both pager and AWS output prompts
+    mock_select.return_value.ask.side_effect = ["true", "cat", "json"]
+    mock_text.return_value.ask.side_effect = [
+        "main",
+        "3.12.9",
+        "Developer",
+        "github.com",
+        "user",
+        "user@example.com",
+        "",
+    ]
+    mock_password.return_value.ask.return_value = "token123"
+
+    result = prompt_env_values()
+
+    assert result["PAGER"] == "cat"  # Default pager
+    assert result["AWS_DEFAULT_OUTPUT"] == "json"  # Default AWS output

--- a/caylent-devcontainer-cli/tests/unit/test_setup.py
+++ b/caylent-devcontainer-cli/tests/unit/test_setup.py
@@ -1268,7 +1268,7 @@ def test_check_and_create_tool_versions_not_exists(mock_file, mock_input, mock_e
 
     mock_file.assert_called_once_with("/test/path/.tool-versions", "w")
     mock_file().write.assert_called_once_with("python 3.12.9\n")
-    mock_input.assert_called_once_with("Press any key to create the file...")
+    mock_input.assert_called_once_with("Press Enter to create the file...")
 
 
 @patch("os.path.exists", return_value=False)

--- a/caylent-devcontainer-cli/tests/unit/test_setup_interactive.py
+++ b/caylent-devcontainer-cli/tests/unit/test_setup_interactive.py
@@ -255,6 +255,66 @@ def test_prompt_env_values_none_extra_packages(mock_select, mock_text, mock_pass
         prompt_env_values()
 
 
+@patch("questionary.password")
+@patch("questionary.text")
+@patch("questionary.select")
+def test_prompt_env_values_complete_with_aws_enabled(mock_select, mock_text, mock_password):
+    """Test prompt_env_values with complete input and AWS enabled."""
+    from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
+
+    mock_select.return_value.ask.side_effect = ["true", "less", "table"]
+    mock_text.return_value.ask.side_effect = [
+        "main",
+        "3.12.9",
+        "Developer",
+        "github.com",
+        "user",
+        "user@example.com",
+        "curl wget",
+    ]
+    mock_password.return_value.ask.return_value = "token123"
+
+    result = prompt_env_values()
+
+    assert result["AWS_CONFIG_ENABLED"] == "true"
+    assert result["DEFAULT_GIT_BRANCH"] == "main"
+    assert result["DEFAULT_PYTHON_VERSION"] == "3.12.9"
+    assert result["DEVELOPER_NAME"] == "Developer"
+    assert result["GIT_PROVIDER_URL"] == "github.com"
+    assert result["GIT_USER"] == "user"
+    assert result["GIT_USER_EMAIL"] == "user@example.com"
+    assert result["GIT_TOKEN"] == "token123"
+    assert result["EXTRA_APT_PACKAGES"] == "curl wget"
+    assert result["PAGER"] == "less"
+    assert result["AWS_DEFAULT_OUTPUT"] == "table"
+
+
+@patch("questionary.password")
+@patch("questionary.text")
+@patch("questionary.select")
+def test_prompt_env_values_complete_with_aws_disabled(mock_select, mock_text, mock_password):
+    """Test prompt_env_values with complete input and AWS disabled."""
+    from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
+
+    mock_select.return_value.ask.side_effect = ["false", "cat"]
+    mock_text.return_value.ask.side_effect = [
+        "main",
+        "3.12.9",
+        "Developer",
+        "github.com",
+        "user",
+        "user@example.com",
+        "",
+    ]
+    mock_password.return_value.ask.return_value = "token123"
+
+    result = prompt_env_values()
+
+    assert result["AWS_CONFIG_ENABLED"] == "false"
+    assert result["PAGER"] == "cat"
+    assert "AWS_DEFAULT_OUTPUT" not in result
+
+
 @patch("questionary.select")
 def test_load_template_version_mismatch_upgrade(mock_select):
     """Test load_template_from_file with version mismatch - upgrade choice."""


### PR DESCRIPTION
# Expand devcontainer validation, CICD toggle, tooling improvements, and WSL support

## Overview
This PR strengthens the Caylent devcontainer by adding explicit validation, improved configurability, better tooling defaults, and comprehensive Windows Subsystem for Linux (WSL) support. These changes ensure consistent behavior across developer machines and CICD pipelines, while removing brittle or hidden logic in setup.

## Detailed Changes

### Validation
- Devcontainers now validate the presence of a `.tool-versions` file whenever launched with `cdevcontainer code <project>`.
- The `.tool-versions` file must include a Python version entry (e.g., `python 3.12.9`), preventing runtime drift across environments.

### CICD Mode
- Introduced a toggle in `.devcontainer/.devcontainer.postcreate.sh` to enable/disable AWS and Git configuration.
- CICD mode:
  - Skips developer-specific configuration (AWS profiles, Git identity)
  - Ensures reproducibility for CICD build agents
  - Persists CICD state into all shell environments (`bash`, `zsh`) for predictable behavior

### Shell and AWS CLI Configuration
- Added options to configure the shell pager (e.g., `less`, `cat`, or custom).
- Added options to define AWS CLI output format, improving usability and consistency in multi-developer environments.

### Tooling Enhancements
- GitHub CLI (`gh`) added to the default toolchain, making GitHub operations first-class inside the devcontainer.
- Caylent Devcontainer CLI installation is now recommended via `pipx`:
  - Avoids conflicts with the system’s Python packages
  - Simplifies upgrades and isolation of dependencies

### Line Ending Management
- Introduced a performant script to bulk-convert files from CRLF → LF line endings.
- Updated default Git configuration:
  - Repositories clone with Unix line endings by default
  - Prevents mixed environments across platforms

### Setup-devcontainer Workflow
- New override capability:
  - Developers can replace template files during `setup-devcontainer` with a specified git ref to test updates before semantic release.
- Removed fallback logic:
  - Previously, if a semantic release of the CLI was missing in Git, setup-devcontainer attempted hidden fallbacks.
  - Now requires explicit release publishing, improving reliability and transparency.

### WSL Support
- Comprehensive improvements for running devcontainers inside Windows Subsystem for Linux (WSL):
  - `devcontainer.json` launches post-create command that enforces LF line endings
  - Post-create script updates:
    - Ensures shell environment variables load consistently across shells
    - Normalizes shell commands for compatibility in WSL
  - `setup-container` flow updated for WSL compatibility and reproducibility

## Impact
- **Developers**: Fail-fast validation ensures runtime consistency, better tooling defaults improve productivity, and WSL support removes friction on Windows machines.
- **CICD Pipelines**: Containers can run without unnecessary AWS/Git setup, enabling clean build agent workflows.
- **Platform Consistency**: All developers and pipelines align on line endings, tool installation methods, and runtime configuration.

## Next Steps
- Expand validation to cover other required runtimes/tools in `.tool-versions`.
- Add automated CI checks for WSL compatibility.
- Consider extending override mechanism to support partial template patching.
