### PR TITLE
feat: add manual update notification system

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,12 +693,7 @@ If the validation succeeds, you'll see:
 > shell.env
 > ```
 >
-> This approach lets you version control the devcontainer configuration while excluding sensitive information. When you need to update the devcontainer, run:
-> ```bash
-> cdevcontainer setup-devcontainer --update .
-> git add .devcontainer
-> git commit -m "chore: Update devcontainer to version X.Y.Z"
-> ```
+> This approach lets you version control the devcontainer configuration while excluding sensitive information.
 
 ---
 

--- a/caylent-devcontainer-cli/README.md
+++ b/caylent-devcontainer-cli/README.md
@@ -67,6 +67,56 @@ cdevcontainer --help
 - `install`: Install the CLI tool to your PATH
 - `uninstall`: Uninstall the CLI tool
 
+### Global Options
+
+- `-y, --yes`: Automatically answer yes to all prompts
+- `-v, --version`: Show version information
+- `--skip-update-check`: Skip automatic update check
+
+### Update Notifications
+
+The CLI automatically checks for updates when run in interactive environments and provides manual upgrade instructions:
+
+```bash
+🔄 Update Available
+Current version: 1.10.0
+Latest version:  1.11.0
+
+Select an option:
+  1 - Exit and upgrade manually
+  2 - Continue without upgrading
+
+Enter your choice [1]:
+```
+
+**Manual Upgrade Instructions by Installation Type:**
+- **pipx installations**: `pipx upgrade caylent-devcontainer-cli`
+- **pip installations**: Switch to pipx (recommended) or upgrade with pip
+- **Editable installations**: Pull latest changes and reinstall, or switch to pipx
+
+**Update Check Behavior:**
+- **Interactive environments**: Shows update notifications with manual upgrade instructions
+- **Non-interactive environments**: Skips update checks silently (CI/CD, scripts, etc.)
+- **Skip mechanisms**: Use `--skip-update-check` flag or set `CDEVCONTAINER_SKIP_UPDATE=1`
+
+**Environment Variables:**
+- `CDEVCONTAINER_SKIP_UPDATE=1`: Globally disable all automatic update checks
+- `CDEVCONTAINER_DEBUG_UPDATE=1`: Enable debug logging for update check process
+
+**Debug Mode:**
+To troubleshoot update issues, enable debug logging:
+```bash
+export CDEVCONTAINER_DEBUG_UPDATE=1
+cdevcontainer --version
+```
+
+This will show detailed information about:
+- Update check process and network requests
+- Installation type detection
+- Lock file operations
+
+
+
 ### Setting Up a Devcontainer
 
 ```bash
@@ -75,9 +125,6 @@ cdevcontainer setup-devcontainer /path/to/your/project
 
 # Manual setup (skip interactive prompts)
 cdevcontainer setup-devcontainer --manual /path/to/your/project
-
-# Update existing devcontainer files to the current CLI version
-cdevcontainer setup-devcontainer --update /path/to/your/project
 
 # Use specific git reference (branch, tag, or commit) instead of CLI version
 cdevcontainer setup-devcontainer --ref main /path/to/your/project

--- a/caylent-devcontainer-cli/src/caylent_devcontainer_cli/__main__.py
+++ b/caylent-devcontainer-cli/src/caylent_devcontainer_cli/__main__.py
@@ -1,0 +1,6 @@
+"""Allow caylent_devcontainer_cli to be executed as a module with python -m."""
+
+from caylent_devcontainer_cli.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/caylent-devcontainer-cli/src/caylent_devcontainer_cli/cli.py
+++ b/caylent-devcontainer-cli/src/caylent_devcontainer_cli/cli.py
@@ -1,6 +1,7 @@
 """Main CLI entry point for Caylent Devcontainer CLI."""
 
 import argparse
+import sys
 
 from caylent_devcontainer_cli import __version__
 from caylent_devcontainer_cli.commands import code, env, install, setup, template
@@ -11,6 +12,16 @@ CLI_NAME = "Caylent Devcontainer CLI"
 
 def main():
     """Main entry point for the CLI."""
+    # Lightweight pre-parse for skip-update-check flag
+    skip_update_check = "--skip-update-check" in sys.argv
+
+    # Check for updates before main parsing (unless skipped)
+    if not skip_update_check:
+        from caylent_devcontainer_cli.utils.version import check_for_updates
+
+        if not check_for_updates():
+            sys.exit(1)
+
     # Create the main parser
     parser = argparse.ArgumentParser(
         description=f"{CLI_NAME} - Manage devcontainer environments",
@@ -20,6 +31,7 @@ def main():
     # Add global options
     parser.add_argument("-y", "--yes", action="store_true", help="Automatically answer yes to all prompts")
     parser.add_argument("-v", "--version", action="version", version=f"{CLI_NAME} {__version__}")
+    parser.add_argument("--skip-update-check", action="store_true", help="Skip automatic update check")
 
     # Create subparsers
     subparsers = parser.add_subparsers(dest="command", help="Command to run")

--- a/caylent-devcontainer-cli/src/caylent_devcontainer_cli/utils/version.py
+++ b/caylent-devcontainer-cli/src/caylent_devcontainer_cli/utils/version.py
@@ -1,0 +1,262 @@
+"""Version checking and update utilities for the Caylent Devcontainer CLI."""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from caylent_devcontainer_cli import __version__
+from caylent_devcontainer_cli.utils.ui import COLORS
+
+# Exit codes
+EXIT_OK = 0
+EXIT_UPGRADE_REQUESTED_ABORT = 21
+
+
+def _debug_log(message):
+    """Log debug message if debug mode is enabled."""
+    if os.getenv("CDEVCONTAINER_DEBUG_UPDATE") == "1":
+        print(f"DEBUG: {message}", file=sys.stderr)
+
+
+def _is_interactive_shell():
+    """Check if running in an interactive shell."""
+    # Skip in CI environments
+    if os.getenv("CI") == "true":
+        _debug_log("Update check skipped (reason: ci-environment)")
+        return False
+
+    # Check for pytest without TTY
+    if "pytest" in sys.argv[0] and not sys.stdin.isatty():
+        _debug_log("Update check skipped (reason: pytest-no-tty)")
+        return False
+
+    # If we have both stdin and stdout TTY, we're interactive
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        return True
+
+    # If we have at least stdout TTY and shell interactive flag, we're interactive
+    if sys.stdout.isatty():
+        shell_opts = os.getenv("-", "")
+        if shell_opts and "i" in shell_opts:
+            return True
+
+    # If TERM is set and we're not in a pipe, assume interactive
+    if os.getenv("TERM") and sys.stdout.isatty():
+        return True
+
+    _debug_log("Update check skipped (reason: non-interactive)")
+    return False
+
+
+def _get_latest_version():
+    """Fetch latest version from PyPI."""
+    try:
+        req = Request("https://pypi.org/pypi/caylent-devcontainer-cli/json")
+        req.add_header("User-Agent", f"caylent-devcontainer-cli/{__version__}")
+
+        # Set socket timeouts: connect=2s, read=3s
+        old_timeout = socket.getdefaulttimeout()
+        socket.setdefaulttimeout(2)
+
+        with urlopen(req, timeout=3) as response:
+            if response.status != 200:
+                _debug_log(f"Update check skipped (reason: http-status {response.status})")
+                return None
+
+            data = response.read()
+            if len(data) > 200 * 1024:  # 200KB limit
+                _debug_log("Update check skipped (reason: oversized-response)")
+                return None
+
+            json_data = json.loads(data.decode())
+            return json_data["info"]["version"]
+
+    except (URLError, OSError, socket.timeout):
+        _debug_log("Update check skipped (reason: network-timeout)")
+        return None
+    except (json.JSONDecodeError, KeyError):
+        _debug_log("Update check skipped (reason: invalid-json)")
+        return None
+    finally:
+        try:
+            socket.setdefaulttimeout(old_timeout)
+        except Exception:
+            pass
+
+
+def _version_is_newer(latest, current):
+    """Compare versions using semantic versioning."""
+    try:
+        from packaging import version
+
+        return version.parse(latest) > version.parse(current)
+    except Exception as e:
+        _debug_log(f"Version parse failed: {e}")
+        return False
+
+
+def _is_installed_with_pipx():
+    """Check if CLI is installed with pipx and return the command to use."""
+    # Try direct pipx first
+    try:
+        result = subprocess.run(["pipx", "list", "--json"], capture_output=True, text=True, timeout=10)
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+            if "caylent-devcontainer-cli" in data.get("venvs", {}):
+                return True
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError, json.JSONDecodeError, FileNotFoundError):
+        pass
+
+    # Try python -m pipx
+    try:
+        result = subprocess.run(["python", "-m", "pipx", "list", "--json"], capture_output=True, text=True, timeout=10)
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+            if "caylent-devcontainer-cli" in data.get("venvs", {}):
+                return True
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError, json.JSONDecodeError, FileNotFoundError):
+        pass
+
+    return False
+
+
+def _is_editable_installation():
+    """Check if this is an editable/development installation."""
+    try:
+        import caylent_devcontainer_cli
+
+        path = caylent_devcontainer_cli.__file__
+
+        # Check if it's in site-packages or dist-packages (regular installation)
+        if "site-packages" in path or "dist-packages" in path:
+            return False
+
+        # For pipx, check if it's truly editable by looking for .egg-link or pth files
+        if _is_installed_with_pipx():
+            # If installed with pipx from local source, check for editable markers
+            import os
+
+            parent_dir = os.path.dirname(path)
+            # Look for .egg-link file which indicates editable installation
+            for root, dirs, files in os.walk(parent_dir):
+                if any(f.endswith(".egg-link") for f in files):
+                    return True
+            # If no .egg-link found, it's likely pipx install . (not editable)
+            return False
+        else:
+            # For pip installations, if not in site-packages, assume editable
+            return True
+    except Exception:
+        return False
+
+
+def _get_installation_type_display():
+    """Get human-readable installation type."""
+    is_pipx = _is_installed_with_pipx()
+    is_editable = _is_editable_installation()
+
+    if is_pipx and is_editable:
+        return "pipx editable"
+    elif is_pipx:
+        return "pipx"
+    elif is_editable:
+        return "pip editable"
+    else:
+        return "pip"
+
+
+def _show_update_prompt(current, latest):
+    """Show update prompt and handle user choice."""
+    install_type_display = _get_installation_type_display()
+
+    print("\n🔄 Update Available")
+    print(f"Current version: {COLORS['RED']}{current}{COLORS['RESET']} ({install_type_display})")
+    print(f"Latest version:  {latest}")
+    print()
+    print("Select an option:")
+    print("  1 - Exit and upgrade manually")
+    print("  2 - Continue without upgrading")
+    print()
+    choice = input("Enter your choice [1]: ").strip() or "1"
+
+    if choice == "1":
+        print("\nExiting so you can upgrade manually.")
+        _show_manual_upgrade_instructions(install_type_display)
+        return EXIT_UPGRADE_REQUESTED_ABORT
+    else:
+        return EXIT_OK
+
+
+def _show_manual_upgrade_instructions(install_type):
+    """Show manual upgrade instructions based on installation type."""
+    print("\nFirst, install pipx:")
+    print("  python -m pip install pipx")
+    print()
+
+    if install_type == "pipx":
+        print("\nUpgrade with pipx:")
+        print("  pipx upgrade caylent-devcontainer-cli")
+
+    elif install_type == "pipx editable":
+        print("\nUpgrade editable installation:")
+        print("  cd /path/to/caylent-devcontainer-cli")
+        print("  git pull")
+        print("  pipx reinstall -e .")
+        print()
+        print("Or switch to regular pipx installation:")
+        print("  pipx uninstall caylent-devcontainer-cli")
+        print("  pipx install caylent-devcontainer-cli")
+
+    elif install_type == "pip editable":
+        print("\nUpgrade editable installation:")
+        print("  cd /path/to/caylent-devcontainer-cli")
+        print("  git pull")
+        print("  pip install -e .")
+        print()
+        print("Or switch to pipx (recommended):")
+        print("  pip uninstall caylent-devcontainer-cli")
+        print("  pipx install caylent-devcontainer-cli")
+
+    else:  # pip
+        print("\nSwitch to pipx:")
+        print("  pip uninstall caylent-devcontainer-cli")
+        print("  pipx install caylent-devcontainer-cli")
+
+
+def check_for_updates():
+    """Main update check function. Returns True to continue, False to exit."""
+    # Check skip conditions
+    if os.getenv("CDEVCONTAINER_SKIP_UPDATE") == "1":
+        _debug_log("Update check skipped (reason: global disable env)")
+        return True
+
+    if not _is_interactive_shell():
+        return True
+
+    try:
+        # Get latest version
+        latest = _get_latest_version()
+        if not latest:
+            return True
+
+        # Compare versions
+        if not _version_is_newer(latest, __version__):
+            print(f"✅ You're running the latest version ({__version__})")
+            return True
+
+        # Show update prompt
+        exit_code = _show_update_prompt(__version__, latest)
+
+        if exit_code == EXIT_OK:
+            return True
+        elif exit_code == EXIT_UPGRADE_REQUESTED_ABORT:
+            sys.exit(exit_code)
+        else:
+            return True
+
+    except Exception:
+        return True

--- a/caylent-devcontainer-cli/tests/functional/test_installation_detection.py
+++ b/caylent-devcontainer-cli/tests/functional/test_installation_detection.py
@@ -18,7 +18,7 @@ class TestInstallationDisplayIntegration(TestCase):
         """Test pipx regular installation display."""
         mock_pipx.return_value = True
         mock_editable.return_value = False
-        mock_input.return_value = "3"  # Continue without upgrading
+        mock_input.return_value = "2"  # Continue without upgrading
 
         _show_update_prompt("1.10.0", "1.11.0")
 
@@ -35,7 +35,7 @@ class TestInstallationDisplayIntegration(TestCase):
         """Test pipx editable installation display."""
         mock_pipx.return_value = True
         mock_editable.return_value = True
-        mock_input.return_value = "3"  # Continue without upgrading
+        mock_input.return_value = "2"  # Continue without upgrading
 
         _show_update_prompt("1.10.0", "1.11.0")
 
@@ -52,7 +52,7 @@ class TestInstallationDisplayIntegration(TestCase):
         """Test pip regular installation display."""
         mock_pipx.return_value = False
         mock_editable.return_value = False
-        mock_input.return_value = "3"  # Continue without upgrading
+        mock_input.return_value = "2"  # Continue without upgrading
 
         _show_update_prompt("1.10.0", "1.11.0")
 
@@ -69,7 +69,7 @@ class TestInstallationDisplayIntegration(TestCase):
         """Test pip editable installation display."""
         mock_pipx.return_value = False
         mock_editable.return_value = True
-        mock_input.return_value = "3"  # Continue without upgrading
+        mock_input.return_value = "2"  # Continue without upgrading
 
         _show_update_prompt("1.10.0", "1.11.0")
 

--- a/caylent-devcontainer-cli/tests/functional/test_installation_detection.py
+++ b/caylent-devcontainer-cli/tests/functional/test_installation_detection.py
@@ -1,0 +1,79 @@
+"""Functional tests for installation type detection."""
+
+import unittest.mock as mock
+from io import StringIO
+from unittest import TestCase
+
+from caylent_devcontainer_cli.utils.version import _show_update_prompt
+
+
+class TestInstallationDisplayIntegration(TestCase):
+    """Test installation type display in update prompts."""
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pipx_regular_display(self, mock_stdout, mock_editable, mock_pipx, mock_input):
+        """Test pipx regular installation display."""
+        mock_pipx.return_value = True
+        mock_editable.return_value = False
+        mock_input.return_value = "3"  # Continue without upgrading
+
+        _show_update_prompt("1.10.0", "1.11.0")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Current version:", output)
+        self.assertIn("1.10.0", output)
+        self.assertIn("(pipx)", output)
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pipx_editable_display(self, mock_stdout, mock_editable, mock_pipx, mock_input):
+        """Test pipx editable installation display."""
+        mock_pipx.return_value = True
+        mock_editable.return_value = True
+        mock_input.return_value = "3"  # Continue without upgrading
+
+        _show_update_prompt("1.10.0", "1.11.0")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Current version:", output)
+        self.assertIn("1.10.0", output)
+        self.assertIn("(pipx editable)", output)
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pip_regular_display(self, mock_stdout, mock_editable, mock_pipx, mock_input):
+        """Test pip regular installation display."""
+        mock_pipx.return_value = False
+        mock_editable.return_value = False
+        mock_input.return_value = "3"  # Continue without upgrading
+
+        _show_update_prompt("1.10.0", "1.11.0")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Current version:", output)
+        self.assertIn("1.10.0", output)
+        self.assertIn("(pip)", output)
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pip_editable_display(self, mock_stdout, mock_editable, mock_pipx, mock_input):
+        """Test pip editable installation display."""
+        mock_pipx.return_value = False
+        mock_editable.return_value = True
+        mock_input.return_value = "3"  # Continue without upgrading
+
+        _show_update_prompt("1.10.0", "1.11.0")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Current version:", output)
+        self.assertIn("1.10.0", output)
+        self.assertIn("(pip editable)", output)

--- a/caylent-devcontainer-cli/tests/functional/test_interactive_upgrade.py
+++ b/caylent-devcontainer-cli/tests/functional/test_interactive_upgrade.py
@@ -1,0 +1,109 @@
+"""Functional tests for interactive upgrade flows."""
+
+import unittest.mock as mock
+from io import StringIO
+from unittest import TestCase
+
+from caylent_devcontainer_cli.utils.version import (
+    EXIT_OK,
+    EXIT_UPGRADE_REQUESTED_ABORT,
+    _show_update_prompt,
+)
+
+
+class TestInteractiveUpgradeFlow(TestCase):
+    """Test interactive upgrade user flows."""
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pipx_upgrade_choice_continue(self, mock_stdout, mock_editable, mock_pipx, mock_input):
+        """Test pipx installation with continue choice."""
+        mock_pipx.return_value = True
+        mock_editable.return_value = False
+        mock_input.return_value = "2"  # Continue without upgrading (now option 2)
+
+        result = _show_update_prompt("1.10.0", "1.11.0")
+
+        self.assertEqual(result, EXIT_OK)
+        output = mock_stdout.getvalue()
+        self.assertIn("Update Available", output)
+        # Remove ANSI color codes for comparison
+        clean_output = output.replace("\x1b[1;31m", "").replace("\x1b[0m", "")
+        self.assertIn("Current version: 1.10.0", clean_output)
+        self.assertIn("Latest version:  1.11.0", output)
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pipx_upgrade_choice_manual(self, mock_stdout, mock_editable, mock_pipx, mock_input):
+        """Test pipx installation with manual upgrade choice."""
+        mock_pipx.return_value = True
+        mock_editable.return_value = False
+        mock_input.return_value = "1"  # Exit and upgrade manually (now option 1)
+
+        result = _show_update_prompt("1.10.0", "1.11.0")
+
+        self.assertEqual(result, EXIT_UPGRADE_REQUESTED_ABORT)
+        output = mock_stdout.getvalue()
+        self.assertIn("Exiting so you can upgrade manually", output)
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pip_installation_flow(self, mock_stdout, mock_editable, mock_pipx, mock_input):
+        """Test pip installation upgrade flow."""
+        mock_pipx.return_value = False
+        mock_editable.return_value = False
+        mock_input.return_value = "1"  # Exit and upgrade manually
+
+        result = _show_update_prompt("1.10.0", "1.11.0")
+
+        self.assertEqual(result, EXIT_UPGRADE_REQUESTED_ABORT)  # Now exits for manual upgrade
+        output = mock_stdout.getvalue()
+        self.assertIn("Select an option:", output)
+        self.assertIn("Exit and upgrade manually", output)
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_editable_installation_flow(self, mock_stdout, mock_editable, mock_pipx, mock_input):
+        """Test editable installation upgrade flow."""
+        mock_pipx.return_value = False
+        mock_editable.return_value = True
+        mock_input.return_value = "1"  # Exit and upgrade manually
+
+        result = _show_update_prompt("1.10.0", "1.11.0")
+
+        self.assertEqual(result, EXIT_UPGRADE_REQUESTED_ABORT)  # Now exits for manual upgrade
+        output = mock_stdout.getvalue()
+        self.assertIn("Select an option:", output)
+        self.assertIn("Exit and upgrade manually", output)
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    def test_default_choice_handling(self, mock_editable, mock_pipx, mock_input):
+        """Test default choice handling (empty input)."""
+        mock_pipx.return_value = True
+        mock_editable.return_value = False
+        mock_input.return_value = ""  # Empty input should use default [1]
+
+        result = _show_update_prompt("1.10.0", "1.11.0")
+        self.assertEqual(result, EXIT_UPGRADE_REQUESTED_ABORT)  # Default is now manual upgrade
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    def test_invalid_choice_handling(self, mock_editable, mock_pipx, mock_input):
+        """Test invalid choice defaults to continue."""
+        mock_pipx.return_value = True
+        mock_editable.return_value = False
+        mock_input.return_value = "99"  # Invalid choice
+
+        result = _show_update_prompt("1.10.0", "1.11.0")
+        self.assertEqual(result, EXIT_OK)  # Should default to continue

--- a/caylent-devcontainer-cli/tests/functional/test_requirements_compliance.py
+++ b/caylent-devcontainer-cli/tests/functional/test_requirements_compliance.py
@@ -1,0 +1,205 @@
+"""Comprehensive test to verify all update feature requirements are implemented."""
+
+import os
+import subprocess
+import sys
+import unittest.mock as mock
+from unittest import TestCase
+
+from caylent_devcontainer_cli.utils.version import (
+    EXIT_OK,
+    EXIT_UPGRADE_REQUESTED_ABORT,
+    _debug_log,
+    _get_latest_version,
+    _is_interactive_shell,
+    check_for_updates,
+)
+
+
+class TestRequirementsCompliance(TestCase):
+    """Test that all requirements from the specification are implemented."""
+
+    def test_exit_codes_defined(self):
+        """Test that all required exit codes are defined."""
+        expected_codes = [
+            EXIT_OK,
+            EXIT_UPGRADE_REQUESTED_ABORT,
+        ]
+
+        # Verify codes are integers and unique
+        self.assertEqual(len(set(expected_codes)), len(expected_codes))
+        for code in expected_codes:
+            self.assertIsInstance(code, int)
+
+    @mock.patch.dict(os.environ, {"CDEVCONTAINER_SKIP_UPDATE": "1"})
+    def test_global_disable_environment_variable(self):
+        """Test CDEVCONTAINER_SKIP_UPDATE=1 disables all update checks."""
+        result = check_for_updates()
+        self.assertTrue(result)
+
+    def test_skip_update_check_flag_in_cli(self):
+        """Test --skip-update-check flag is recognized by CLI."""
+        result = subprocess.run(
+            [sys.executable, "-m", "caylent_devcontainer_cli.cli", "--skip-update-check", "--help"],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("--skip-update-check", result.stdout)
+
+    @mock.patch.dict(os.environ, {"CI": "true"})
+    def test_ci_environment_detection(self):
+        """Test CI environment is detected and skips update checks."""
+        self.assertFalse(_is_interactive_shell())
+
+    @mock.patch("sys.stdin.isatty")
+    @mock.patch("sys.stdout.isatty")
+    def test_non_interactive_tty_detection(self, mock_stdout_tty, mock_stdin_tty):
+        """Test non-interactive TTY detection."""
+        mock_stdin_tty.return_value = False
+        mock_stdout_tty.return_value = True
+        self.assertFalse(_is_interactive_shell())
+
+    @mock.patch.dict(os.environ, {"CDEVCONTAINER_DEBUG_UPDATE": "1"})
+    def test_debug_logging_enabled(self):
+        """Test debug logging works when enabled."""
+        with mock.patch("sys.stderr") as mock_stderr:
+            _debug_log("test message")
+            mock_stderr.write.assert_called()
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_debug_logging_disabled(self):
+        """Test debug logging is silent when disabled."""
+        with mock.patch("sys.stderr") as mock_stderr:
+            _debug_log("test message")
+            mock_stderr.write.assert_not_called()
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_network_timeout_configuration(self, mock_urlopen):
+        """Test network requests use proper timeout configuration."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = b'{"info": {"version": "1.12.0"}}'
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        version = _get_latest_version()
+        self.assertEqual(version, "1.12.0")
+
+        # Verify timeout was set
+        mock_urlopen.assert_called_once()
+        args, kwargs = mock_urlopen.call_args
+        self.assertEqual(kwargs.get("timeout"), 3)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_user_agent_header(self, mock_urlopen):
+        """Test User-Agent header is set correctly."""
+        from caylent_devcontainer_cli import __version__
+
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = b'{"info": {"version": "1.12.0"}}'
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        _get_latest_version()
+
+        # Check that request was made with proper User-Agent
+        args, kwargs = mock_urlopen.call_args
+        request = args[0]
+        self.assertEqual(request.get_header("User-agent"), f"caylent-devcontainer-cli/{__version__}")
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_response_size_limit(self, mock_urlopen):
+        """Test response size limit is enforced."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        # Create response larger than 200KB
+        large_data = "x" * (201 * 1024)
+        mock_response.read.return_value = large_data.encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        version = _get_latest_version()
+        self.assertIsNone(version)
+
+    def test_packaging_dependency_available(self):
+        """Test packaging dependency is available for version comparison."""
+        try:
+            from packaging import version
+
+            # Should be able to parse versions
+            v1 = version.parse("1.10.0")
+            v2 = version.parse("1.11.0")
+            self.assertTrue(v2 > v1)
+        except ImportError:
+            self.fail("packaging dependency not available")
+
+    @mock.patch.dict(os.environ, {"-": "himBH"})  # Interactive bash
+    def test_shell_interactive_flag_detection(self):
+        """Test shell interactive flag detection using $- variable."""
+        with mock.patch("sys.stdin.isatty", return_value=True):
+            with mock.patch("sys.stdout.isatty", return_value=True):
+                with mock.patch.dict(os.environ, {"CI": ""}, clear=False):
+                    result = _is_interactive_shell()
+                    self.assertTrue(result)
+
+    @mock.patch.dict(os.environ, {"-": "hmBH", "TERM": ""})  # Non-interactive bash (no 'i', no TERM)
+    def test_shell_non_interactive_flag_detection(self):
+        """Test shell non-interactive flag detection."""
+        with mock.patch("sys.stdin.isatty", return_value=False):
+            with mock.patch("sys.stdout.isatty", return_value=True):
+                with mock.patch.dict(os.environ, {"CI": ""}, clear=False):
+                    result = _is_interactive_shell()
+                    self.assertFalse(result)
+
+    def test_pytest_detection(self):
+        """Test pytest environment detection."""
+        # This test itself runs in pytest, so we can verify the detection works
+        # when TTY is not available
+        with mock.patch("sys.stdin.isatty", return_value=False):
+            with mock.patch("sys.argv", ["pytest"]):
+                result = _is_interactive_shell()
+                self.assertFalse(result)
+
+
+class TestErrorHandlingMatrix(TestCase):
+    """Test specific error handling scenarios from the requirements matrix."""
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_http_500_error_handling(self, mock_urlopen):
+        """Test HTTP 500 error is handled silently."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 500
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        version = _get_latest_version()
+        self.assertIsNone(version)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_http_404_error_handling(self, mock_urlopen):
+        """Test HTTP 404 error is handled silently."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 404
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        version = _get_latest_version()
+        self.assertIsNone(version)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_malformed_json_handling(self, mock_urlopen):
+        """Test malformed JSON response is handled silently."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = b"invalid json {"
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+
+        version = _get_latest_version()
+        self.assertIsNone(version)
+
+    @mock.patch("socket.timeout")
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_socket_timeout_handling(self, mock_urlopen, mock_timeout):
+        """Test socket timeout is handled silently."""
+        mock_urlopen.side_effect = mock_timeout()
+
+        version = _get_latest_version()
+        self.assertIsNone(version)

--- a/caylent-devcontainer-cli/tests/functional/test_update_check.py
+++ b/caylent-devcontainer-cli/tests/functional/test_update_check.py
@@ -1,0 +1,62 @@
+"""Functional tests for CLI update checking."""
+
+import os
+import subprocess
+import sys
+import unittest.mock as mock
+from unittest import TestCase
+
+
+class TestUpdateCheckIntegration(TestCase):
+    """Test update check integration with CLI."""
+
+    def test_skip_update_check_flag(self):
+        """Test --skip-update-check flag works."""
+        # This should run without any update checks
+        result = subprocess.run(
+            [sys.executable, "-m", "caylent_devcontainer_cli.cli", "--skip-update-check", "--help"],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("usage:", result.stdout)
+
+    @mock.patch.dict(os.environ, {"CDEVCONTAINER_SKIP_UPDATE": "1"})
+    def test_skip_update_env_var(self):
+        """Test CDEVCONTAINER_SKIP_UPDATE environment variable."""
+        result = subprocess.run(
+            [sys.executable, "-m", "caylent_devcontainer_cli.cli", "--help"], capture_output=True, text=True
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("usage:", result.stdout)
+
+    @mock.patch.dict(os.environ, {"CI": "true"})
+    def test_ci_environment_skip(self):
+        """Test update check is skipped in CI environment."""
+        result = subprocess.run(
+            [sys.executable, "-m", "caylent_devcontainer_cli.cli", "--help"], capture_output=True, text=True
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("usage:", result.stdout)
+
+    def test_version_command_works(self):
+        """Test --version command still works with update checking."""
+        result = subprocess.run(
+            [sys.executable, "-m", "caylent_devcontainer_cli.cli", "--version"], capture_output=True, text=True
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Caylent Devcontainer CLI", result.stdout)
+
+    def test_non_interactive_bash_command(self):
+        """Test CLI works in non-interactive bash context."""
+        # Simulate bash -c execution
+        result = subprocess.run(
+            ["bash", "-c", f"{sys.executable} -m caylent_devcontainer_cli.cli --help"], capture_output=True, text=True
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("usage:", result.stdout)

--- a/caylent-devcontainer-cli/tests/functional/test_upgrade_scenarios.py
+++ b/caylent-devcontainer-cli/tests/functional/test_upgrade_scenarios.py
@@ -1,0 +1,91 @@
+"""Functional tests for upgrade scenarios."""
+
+import unittest.mock as mock
+from io import StringIO
+from unittest import TestCase
+
+from caylent_devcontainer_cli.utils.version import (
+    EXIT_UPGRADE_REQUESTED_ABORT,
+    _show_manual_upgrade_instructions,
+    _show_update_prompt,
+)
+
+
+class TestUpgradeScenarios(TestCase):
+    """Test upgrade scenarios for different installation types."""
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    def test_pipx_regular_option1_upgrade(self, mock_editable, mock_pipx, mock_input):
+        """Test Option 1 manual upgrade for pipx regular installation."""
+        mock_pipx.return_value = True
+        mock_editable.return_value = False
+        mock_input.return_value = "1"
+
+        result = _show_update_prompt("1.10.0", "1.11.0")
+
+        self.assertEqual(result, EXIT_UPGRADE_REQUESTED_ABORT)
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    def test_pipx_editable_option1_upgrade(self, mock_editable, mock_pipx, mock_input):
+        """Test Option 1 manual upgrade for pipx editable installation."""
+        mock_pipx.return_value = True
+        mock_editable.return_value = True
+        mock_input.return_value = "1"
+
+        result = _show_update_prompt("1.10.0", "1.11.0")
+
+        self.assertEqual(result, EXIT_UPGRADE_REQUESTED_ABORT)
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    def test_pip_regular_option1_upgrade(self, mock_editable, mock_pipx, mock_input):
+        """Test Option 1 manual upgrade for pip regular installation."""
+        mock_pipx.return_value = False
+        mock_editable.return_value = False
+        mock_input.return_value = "1"
+
+        result = _show_update_prompt("1.10.0", "1.11.0")
+
+        self.assertEqual(result, EXIT_UPGRADE_REQUESTED_ABORT)
+
+    @mock.patch("builtins.input")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    def test_pip_editable_option1_upgrade(self, mock_editable, mock_pipx, mock_input):
+        """Test Option 1 manual upgrade for pip editable installation."""
+        mock_pipx.return_value = False
+        mock_editable.return_value = True
+        mock_input.return_value = "1"
+
+        result = _show_update_prompt("1.10.0", "1.11.0")
+
+        self.assertEqual(result, EXIT_UPGRADE_REQUESTED_ABORT)
+
+
+class TestManualInstructionsWithPipxDetection(TestCase):
+    """Test manual instructions adapt based on pipx availability."""
+
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_manual_instructions_pip(self, mock_stdout):
+        """Test manual instructions for pip installation."""
+        _show_manual_upgrade_instructions("pip")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("First, install pipx:", output)
+        self.assertIn("python -m pip install pipx", output)
+        self.assertIn("Switch to pipx:", output)
+
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_manual_instructions_pipx(self, mock_stdout):
+        """Test manual instructions for pipx installation."""
+        _show_manual_upgrade_instructions("pipx")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("First, install pipx:", output)
+        self.assertIn("Upgrade with pipx:", output)
+        self.assertIn("pipx upgrade caylent-devcontainer-cli", output)

--- a/caylent-devcontainer-cli/tests/unit/test_installation_detection.py
+++ b/caylent-devcontainer-cli/tests/unit/test_installation_detection.py
@@ -1,0 +1,90 @@
+"""Unit tests for installation type detection."""
+
+import json
+import unittest.mock as mock
+from unittest import TestCase
+
+from caylent_devcontainer_cli.utils.version import (
+    _get_installation_type_display,
+    _is_editable_installation,
+    _is_installed_with_pipx,
+)
+
+
+class TestInstallationDetection(TestCase):
+    """Test installation type detection logic."""
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    def test_pipx_regular_detection(self, mock_editable, mock_pipx):
+        """Test detection of pipx regular installation."""
+        mock_pipx.return_value = True
+        mock_editable.return_value = False
+
+        result = _get_installation_type_display()
+        self.assertEqual(result, "pipx")
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    def test_pipx_editable_detection(self, mock_editable, mock_pipx):
+        """Test detection of pipx editable installation."""
+        mock_pipx.return_value = True
+        mock_editable.return_value = True
+
+        result = _get_installation_type_display()
+        self.assertEqual(result, "pipx editable")
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    def test_pip_regular_detection(self, mock_editable, mock_pipx):
+        """Test detection of pip regular installation."""
+        mock_pipx.return_value = False
+        mock_editable.return_value = False
+
+        result = _get_installation_type_display()
+        self.assertEqual(result, "pip")
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation")
+    def test_pip_editable_detection(self, mock_editable, mock_pipx):
+        """Test detection of pip editable installation."""
+        mock_pipx.return_value = False
+        mock_editable.return_value = True
+
+        result = _get_installation_type_display()
+        self.assertEqual(result, "pip editable")
+
+    @mock.patch("subprocess.run")
+    def test_pipx_detection_with_cli_installed(self, mock_run):
+        """Test pipx detection when CLI is installed."""
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"venvs": {"caylent-devcontainer-cli": {}}})
+        mock_run.return_value = mock_result
+
+        result = _is_installed_with_pipx()
+        self.assertTrue(result)
+
+    @mock.patch("subprocess.run")
+    def test_pipx_detection_without_cli_installed(self, mock_run):
+        """Test pipx detection when CLI is not installed."""
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"venvs": {}})
+        mock_run.return_value = mock_result
+
+        result = _is_installed_with_pipx()
+        self.assertFalse(result)
+
+    @mock.patch("subprocess.run")
+    def test_pipx_detection_command_not_found(self, mock_run):
+        """Test pipx detection when pipx is not installed."""
+        mock_run.side_effect = FileNotFoundError()
+
+        result = _is_installed_with_pipx()
+        self.assertFalse(result)
+
+    def test_editable_installation_detection(self):
+        """Test editable installation detection."""
+        result = _is_editable_installation()
+        self.assertIsInstance(result, bool)

--- a/caylent-devcontainer-cli/tests/unit/test_manual_upgrade_instructions.py
+++ b/caylent-devcontainer-cli/tests/unit/test_manual_upgrade_instructions.py
@@ -1,0 +1,58 @@
+"""Unit tests for manual upgrade instructions."""
+
+import unittest.mock as mock
+from io import StringIO
+from unittest import TestCase
+
+from caylent_devcontainer_cli.utils.version import _show_manual_upgrade_instructions
+
+
+class TestManualUpgradeInstructions(TestCase):
+    """Test manual upgrade instructions for different installation types."""
+
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pipx_regular_instructions(self, mock_stdout):
+        """Test manual upgrade instructions for pipx regular installation."""
+        _show_manual_upgrade_instructions("pipx")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Upgrade with pipx:", output)
+        self.assertIn("pipx upgrade caylent-devcontainer-cli", output)
+
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pipx_editable_instructions(self, mock_stdout):
+        """Test manual upgrade instructions for pipx editable installation."""
+        _show_manual_upgrade_instructions("pipx editable")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Upgrade editable installation:", output)
+        self.assertIn("cd /path/to/caylent-devcontainer-cli", output)
+        self.assertIn("git pull", output)
+        self.assertIn("pipx reinstall -e .", output)
+        self.assertIn("Or switch to regular pipx installation:", output)
+        self.assertIn("pipx uninstall caylent-devcontainer-cli", output)
+        self.assertIn("pipx install caylent-devcontainer-cli", output)
+
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pip_editable_instructions(self, mock_stdout):
+        """Test manual upgrade instructions for pip editable installation."""
+        _show_manual_upgrade_instructions("pip editable")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Upgrade editable installation:", output)
+        self.assertIn("cd /path/to/caylent-devcontainer-cli", output)
+        self.assertIn("git pull", output)
+        self.assertIn("pip install -e .", output)
+        self.assertIn("Or switch to pipx (recommended):", output)
+        self.assertIn("pip uninstall caylent-devcontainer-cli", output)
+        self.assertIn("pipx install caylent-devcontainer-cli", output)
+
+    @mock.patch("sys.stdout", new_callable=StringIO)
+    def test_pip_regular_instructions(self, mock_stdout):
+        """Test manual upgrade instructions for pip regular installation."""
+        _show_manual_upgrade_instructions("pip")
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Switch to pipx:", output)
+        self.assertIn("pip uninstall caylent-devcontainer-cli", output)
+        self.assertIn("pipx install caylent-devcontainer-cli", output)

--- a/caylent-devcontainer-cli/tests/unit/test_template.py
+++ b/caylent-devcontainer-cli/tests/unit/test_template.py
@@ -483,3 +483,369 @@ def test_upgrade_template_file_version_check():
         "json.dump"
     ):
         upgrade_template_file("test-template")
+
+
+# Additional tests for missing coverage
+
+
+def test_get_missing_single_line_vars():
+    """Test get_missing_single_line_vars function."""
+    from caylent_devcontainer_cli.commands.template import get_missing_single_line_vars
+
+    container_env = {"EXISTING_VAR": "value"}
+    example_values = {"EXISTING_VAR": "existing", "MISSING_VAR": "default_value", "COMPLEX_VAR": {"nested": "object"}}
+
+    with patch("caylent_devcontainer_cli.commands.template.EXAMPLE_ENV_VALUES", example_values), patch(
+        "caylent_devcontainer_cli.utils.env.is_single_line_env_var", side_effect=lambda x: isinstance(x, str)
+    ):
+        result = get_missing_single_line_vars(container_env)
+        assert "MISSING_VAR" in result
+        assert "EXISTING_VAR" not in result
+        assert "COMPLEX_VAR" not in result
+
+
+def test_prompt_for_missing_vars():
+    """Test prompt_for_missing_vars function."""
+    from caylent_devcontainer_cli.commands.template import prompt_for_missing_vars
+
+    missing_vars = {"VAR1": "default1", "VAR2": "default2"}
+
+    with patch("questionary.confirm") as mock_confirm, patch("questionary.text") as mock_text:
+        mock_confirm_obj = MagicMock()
+        mock_confirm_obj.ask.side_effect = [True, False]  # Use default for VAR1, custom for VAR2
+        mock_confirm.return_value = mock_confirm_obj
+
+        mock_text_obj = MagicMock()
+        mock_text_obj.ask.return_value = "custom_value"
+        mock_text.return_value = mock_text_obj
+
+        result = prompt_for_missing_vars(missing_vars)
+
+        assert result["VAR1"] == "default1"
+        assert result["VAR2"] == "custom_value"
+
+
+def test_upgrade_template_with_missing_vars():
+    """Test upgrade_template_with_missing_vars function."""
+    from caylent_devcontainer_cli.commands.template import upgrade_template_with_missing_vars
+
+    template_data = {"containerEnv": {"EXISTING": "value"}}
+    upgraded_template = {"containerEnv": {"EXISTING": "value", "UPGRADED": "true"}}
+    missing_vars = {"NEW_VAR": "new_value"}
+
+    with patch(
+        "caylent_devcontainer_cli.commands.setup_interactive.upgrade_template", return_value=upgraded_template
+    ), patch(
+        "caylent_devcontainer_cli.commands.template.get_missing_single_line_vars", return_value=missing_vars
+    ), patch(
+        "caylent_devcontainer_cli.commands.template.prompt_for_missing_vars", return_value=missing_vars
+    ):
+
+        result = upgrade_template_with_missing_vars(template_data)
+
+        assert "NEW_VAR" in result["containerEnv"]
+        assert result["containerEnv"]["NEW_VAR"] == "new_value"
+
+
+def test_upgrade_template_with_no_missing_vars():
+    """Test upgrade_template_with_missing_vars with no missing vars."""
+    from caylent_devcontainer_cli.commands.template import upgrade_template_with_missing_vars
+
+    template_data = {"containerEnv": {"EXISTING": "value"}}
+    upgraded_template = {"containerEnv": {"EXISTING": "value", "UPGRADED": "true"}}
+
+    with patch(
+        "caylent_devcontainer_cli.commands.setup_interactive.upgrade_template", return_value=upgraded_template
+    ), patch("caylent_devcontainer_cli.commands.template.get_missing_single_line_vars", return_value={}):
+
+        result = upgrade_template_with_missing_vars(template_data)
+
+        assert result == upgraded_template
+
+
+def test_upgrade_template_file_force():
+    """Test upgrade_template_file with force flag."""
+    template_data = {"containerEnv": {"TEST": "value"}, "cli_version": "1.0.0"}
+    upgraded_data = {"containerEnv": {"TEST": "value", "NEW": "var"}, "cli_version": __version__}
+
+    with patch("os.path.exists", return_value=True), patch(
+        "builtins.open", mock_open(read_data=json.dumps(template_data))
+    ), patch("json.load", return_value=template_data), patch("json.dump"), patch(
+        "caylent_devcontainer_cli.commands.template.upgrade_template_with_missing_vars", return_value=upgraded_data
+    ):
+
+        upgrade_template_file("test-template", force=True)
+
+
+def test_upgrade_template_file_same_version():
+    """Test upgrade_template_file when versions match."""
+    template_data = {"containerEnv": {"TEST": "value"}, "cli_version": __version__}
+
+    with patch("os.path.exists", return_value=True), patch(
+        "builtins.open", mock_open(read_data=json.dumps(template_data))
+    ), patch("json.load", return_value=template_data), patch("json.dump") as mock_dump:
+
+        upgrade_template_file("test-template")
+
+        # Should still update the version even if major.minor match
+        mock_dump.assert_called_once()
+
+
+def test_upgrade_template_file_version_parse_error():
+    """Test upgrade_template_file with version parse error."""
+    template_data = {"containerEnv": {"TEST": "value"}, "cli_version": "invalid.version"}
+    upgraded_data = {"containerEnv": {"TEST": "value"}, "cli_version": __version__}
+
+    with patch("os.path.exists", return_value=True), patch(
+        "builtins.open", mock_open(read_data=json.dumps(template_data))
+    ), patch("json.load", return_value=template_data), patch("json.dump"), patch(
+        "caylent_devcontainer_cli.commands.setup_interactive.upgrade_template", return_value=upgraded_data
+    ):
+
+        upgrade_template_file("test-template")
+
+
+def test_upgrade_template_file_no_version():
+    """Test upgrade_template_file with no version in template."""
+    template_data = {"containerEnv": {"TEST": "value"}}
+    upgraded_data = {"containerEnv": {"TEST": "value"}, "cli_version": __version__}
+
+    with patch("os.path.exists", return_value=True), patch(
+        "builtins.open", mock_open(read_data=json.dumps(template_data))
+    ), patch("json.load", return_value=template_data), patch("json.dump"), patch(
+        "caylent_devcontainer_cli.commands.setup_interactive.upgrade_template", return_value=upgraded_data
+    ):
+
+        upgrade_template_file("test-template")
+
+
+def test_upgrade_template_file_exception():
+    """Test upgrade_template_file with exception."""
+    with patch("os.path.exists", return_value=True), patch("builtins.open", side_effect=Exception("File error")), patch(
+        "sys.exit"
+    ) as mock_exit:
+
+        upgrade_template_file("test-template")
+        mock_exit.assert_called_once_with(1)
+
+
+def test_save_template_no_env_file():
+    """Test save_template when environment file doesn't exist."""
+    with patch("os.path.exists", return_value=False), patch(
+        "caylent_devcontainer_cli.commands.template.ensure_templates_dir"
+    ), patch("sys.exit", side_effect=SystemExit(1)):
+
+        with pytest.raises(SystemExit):
+            save_template("/test/path", "test-template")
+
+
+def test_save_template_confirm_cancel():
+    """Test save_template when user cancels confirmation."""
+    with patch("os.path.exists", side_effect=[True, False]), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", return_value=False
+    ), patch("caylent_devcontainer_cli.commands.template.ensure_templates_dir"), patch(
+        "sys.exit", side_effect=SystemExit(1)
+    ):
+
+        with pytest.raises(SystemExit):
+            save_template("/test/path", "test-template")
+
+
+def test_load_template_version_parse_error():
+    """Test load_template with version parse error."""
+    template_data = {"key": "value", "cli_version": "invalid.version"}
+
+    with patch("os.path.exists", return_value=True), patch(
+        "builtins.open", mock_open(read_data=json.dumps(template_data))
+    ), patch("json.load", return_value=template_data), patch("json.dump"), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", return_value=True
+    ):
+
+        load_template("/test/path", "test-template")
+
+
+def test_load_template_use_anyway_cancel():
+    """Test load_template when user cancels 'use anyway' confirmation."""
+    template_data = {"key": "value", "cli_version": "1.0.0"}
+
+    with patch("caylent_devcontainer_cli.commands.template.__version__", "2.0.0"), patch(
+        "os.path.exists", return_value=True
+    ), patch("builtins.input", return_value="3"), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", side_effect=[True, False]
+    ), patch(
+        "json.load", return_value=template_data
+    ), patch(
+        "sys.exit", side_effect=SystemExit(0)
+    ):
+
+        with pytest.raises(SystemExit):
+            load_template("/test/path", "test-template")
+
+
+def test_delete_template_exception():
+    """Test delete_template with exception during deletion."""
+    with patch("os.path.exists", return_value=True), patch("os.remove", side_effect=Exception("Delete error")), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", return_value=True
+    ):
+
+        delete_template("test-template")
+
+
+def test_list_templates_json_exception():
+    """Test list_templates with JSON exception."""
+    with patch("os.listdir", return_value=["template1.json"]), patch(
+        "caylent_devcontainer_cli.commands.template.ensure_templates_dir"
+    ), patch("builtins.open", side_effect=Exception("JSON error")), patch("builtins.print"):
+
+        list_templates()  # Should handle exception gracefully
+
+
+def test_create_new_template_overwrite():
+    """Test create_new_template with overwrite confirmation."""
+    template_data = {"containerEnv": {"TEST": "value"}, "cli_version": "1.0.0"}
+
+    with patch("os.path.exists", return_value=True), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", return_value=True
+    ), patch("caylent_devcontainer_cli.commands.template.ensure_templates_dir"), patch(
+        "caylent_devcontainer_cli.commands.setup_interactive.create_template_interactive", return_value=template_data
+    ), patch(
+        "caylent_devcontainer_cli.commands.setup_interactive.save_template_to_file"
+    ):
+
+        create_new_template("existing-template")
+
+
+def test_load_template_create_new_env_file():
+    """Test load_template when creating new env file."""
+    template_data = {"key": "value"}
+
+    with patch("os.path.exists", side_effect=[True, False]), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", return_value=True
+    ), patch("builtins.open", mock_open(read_data=json.dumps(template_data))), patch(
+        "json.load", return_value=template_data
+    ), patch(
+        "json.dump"
+    ):
+
+        load_template("/test/path", "test-template")
+
+
+def test_save_template_create_new_template():
+    """Test save_template when creating new template."""
+    mock_env_data = {"key": "value"}
+
+    with patch("os.path.exists", side_effect=[True, False]), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", return_value=True
+    ), patch("caylent_devcontainer_cli.commands.template.ensure_templates_dir"), patch(
+        "builtins.open", mock_open(read_data=json.dumps(mock_env_data))
+    ), patch(
+        "json.load", return_value=mock_env_data
+    ), patch(
+        "json.dump"
+    ):
+
+        save_template("/test/path", "test-template")
+
+
+def test_register_command():
+    """Test register_command function."""
+    from caylent_devcontainer_cli.commands.template import register_command
+
+    mock_subparsers = MagicMock()
+    mock_parser = MagicMock()
+    mock_template_subparsers = MagicMock()
+
+    mock_subparsers.add_parser.return_value = mock_parser
+    mock_parser.add_subparsers.return_value = mock_template_subparsers
+
+    register_command(mock_subparsers)
+
+    # Verify the main template parser was created
+    mock_subparsers.add_parser.assert_called_with("template", help="Template management")
+    # Verify subcommands were added
+    assert mock_template_subparsers.add_parser.call_count >= 5
+
+
+def test_load_template_version_mismatch_choices():
+    """Test load_template version mismatch with different choices."""
+    template_data = {"key": "value", "cli_version": "1.0.0"}
+
+    # Test choice 1 (upgrade)
+    with patch("caylent_devcontainer_cli.commands.template.__version__", "2.0.0"), patch(
+        "os.path.exists", return_value=True
+    ), patch("builtins.input", return_value="1"), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", return_value=True
+    ), patch(
+        "builtins.open", mock_open(read_data=json.dumps(template_data))
+    ), patch(
+        "json.load", return_value=template_data
+    ), patch(
+        "json.dump"
+    ), patch(
+        "caylent_devcontainer_cli.commands.template.upgrade_template", return_value=template_data
+    ):
+
+        load_template("/test/path", "test-template")
+
+
+def test_load_template_version_mismatch_invalid_then_valid():
+    """Test load_template version mismatch with invalid then valid choice."""
+    template_data = {"key": "value", "cli_version": "1.0.0"}
+
+    with patch("caylent_devcontainer_cli.commands.template.__version__", "2.0.0"), patch(
+        "os.path.exists", return_value=True
+    ), patch("builtins.input", side_effect=["invalid", "1"]), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", return_value=True
+    ), patch(
+        "builtins.open", mock_open(read_data=json.dumps(template_data))
+    ), patch(
+        "json.load", return_value=template_data
+    ), patch(
+        "json.dump"
+    ), patch(
+        "caylent_devcontainer_cli.commands.template.upgrade_template", return_value=template_data
+    ), patch(
+        "builtins.print"
+    ):
+
+        load_template("/test/path", "test-template")
+
+
+def test_load_template_version_mismatch_exit():
+    """Test load_template version mismatch with exit choice."""
+    template_data = {"key": "value", "cli_version": "1.0.0"}
+
+    with patch("caylent_devcontainer_cli.commands.template.__version__", "2.0.0"), patch(
+        "os.path.exists", return_value=True
+    ), patch("builtins.input", return_value="4"), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", return_value=True
+    ), patch(
+        "builtins.open", mock_open(read_data=json.dumps(template_data))
+    ), patch(
+        "json.load", return_value=template_data
+    ), patch(
+        "sys.exit", side_effect=SystemExit(0)
+    ):
+
+        with pytest.raises(SystemExit):
+            load_template("/test/path", "test-template")
+
+
+def test_load_template_version_mismatch_new_profile():
+    """Test load_template version mismatch with new profile choice."""
+    template_data = {"key": "value", "cli_version": "1.0.0"}
+
+    with patch("caylent_devcontainer_cli.commands.template.__version__", "2.0.0"), patch(
+        "os.path.exists", return_value=True
+    ), patch("builtins.input", return_value="2"), patch(
+        "caylent_devcontainer_cli.commands.template.confirm_action", return_value=True
+    ), patch(
+        "builtins.open", mock_open(read_data=json.dumps(template_data))
+    ), patch(
+        "json.load", return_value=template_data
+    ), patch(
+        "sys.exit", side_effect=SystemExit(0)
+    ):
+
+        with pytest.raises(SystemExit):
+            load_template("/test/path", "test-template")

--- a/caylent-devcontainer-cli/tests/unit/test_version.py
+++ b/caylent-devcontainer-cli/tests/unit/test_version.py
@@ -147,9 +147,10 @@ class TestVersionUtils(TestCase):
         """Test interactive shell detection without stdin TTY."""
         self.assertFalse(_is_interactive_shell())
 
+    @mock.patch("os.getenv", return_value=None)
     @mock.patch("sys.stdin.isatty", return_value=True)
     @mock.patch("sys.stdout.isatty", return_value=True)
-    def test_is_interactive_shell_both_tty(self, mock_stdout, mock_stdin):
+    def test_is_interactive_shell_both_tty(self, mock_stdout, mock_stdin, mock_getenv):
         """Test interactive shell detection with both TTY."""
         self.assertTrue(_is_interactive_shell())
 

--- a/caylent-devcontainer-cli/tests/unit/test_version.py
+++ b/caylent-devcontainer-cli/tests/unit/test_version.py
@@ -1,0 +1,336 @@
+"""Unit tests for version checking functionality."""
+
+import json
+import os
+import unittest.mock as mock
+from unittest import TestCase
+
+from caylent_devcontainer_cli.utils.version import (
+    EXIT_OK,
+    EXIT_UPGRADE_REQUESTED_ABORT,
+    _debug_log,
+    _get_installation_type_display,
+    _get_latest_version,
+    _is_editable_installation,
+    _is_installed_with_pipx,
+    _is_interactive_shell,
+    _show_manual_upgrade_instructions,
+    _show_update_prompt,
+    _version_is_newer,
+    check_for_updates,
+)
+
+
+class TestVersionUtils(TestCase):
+    """Test version utility functions."""
+
+    def test_version_is_newer(self):
+        """Test version comparison logic."""
+        self.assertTrue(_version_is_newer("1.11.0", "1.10.0"))
+        self.assertFalse(_version_is_newer("1.10.0", "1.11.0"))
+
+    @mock.patch("subprocess.run")
+    def test_is_installed_with_pipx_true(self, mock_run):
+        """Test pipx installation detection when installed."""
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"venvs": {"caylent-devcontainer-cli": {}}})
+        mock_run.return_value = mock_result
+        self.assertTrue(_is_installed_with_pipx())
+
+    @mock.patch.dict(os.environ, {"CI": "true"})
+    def test_is_interactive_shell_ci(self):
+        """Test interactive shell detection in CI."""
+        self.assertFalse(_is_interactive_shell())
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_get_latest_version_success(self, mock_urlopen):
+        """Test successful version fetch from PyPI."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps({"info": {"version": "1.12.0"}}).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+        version = _get_latest_version()
+        self.assertEqual(version, "1.12.0")
+
+    @mock.patch.dict(os.environ, {"CDEVCONTAINER_SKIP_UPDATE": "1"})
+    def test_check_for_updates_skip_env(self):
+        """Test update check with skip environment variable."""
+        result = check_for_updates()
+        self.assertTrue(result)
+
+    @mock.patch("builtins.input", return_value="2")
+    @mock.patch("caylent_devcontainer_cli.utils.version._get_installation_type_display", return_value="pipx")
+    def test_show_update_prompt_continue(self, mock_display, mock_input):
+        """Test update prompt with continue option."""
+        result = _show_update_prompt("1.0.0", "1.1.0")
+        self.assertEqual(result, EXIT_OK)
+
+    @mock.patch("builtins.input", return_value="1")
+    @mock.patch("caylent_devcontainer_cli.utils.version._show_manual_upgrade_instructions")
+    @mock.patch("caylent_devcontainer_cli.utils.version._get_installation_type_display", return_value="pipx")
+    def test_show_update_prompt_exit(self, mock_display, mock_instructions, mock_input):
+        """Test update prompt with exit option."""
+        result = _show_update_prompt("1.0.0", "1.1.0")
+        self.assertEqual(result, EXIT_UPGRADE_REQUESTED_ABORT)
+
+    @mock.patch("builtins.print")
+    def test_show_manual_upgrade_instructions(self, mock_print):
+        """Test manual upgrade instructions."""
+        _show_manual_upgrade_instructions("pipx")
+        _show_manual_upgrade_instructions("pipx editable")
+        _show_manual_upgrade_instructions("pip editable")
+        _show_manual_upgrade_instructions("pip")
+        mock_print.assert_called()
+
+    @mock.patch("subprocess.run")
+    def test_is_installed_with_pipx_false(self, mock_run):
+        """Test pipx installation detection when not installed."""
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"venvs": {}})
+        mock_run.return_value = mock_result
+        self.assertFalse(_is_installed_with_pipx())
+
+    @mock.patch("subprocess.run")
+    def test_is_installed_with_pipx_error(self, mock_run):
+        """Test pipx installation detection with error."""
+        mock_run.side_effect = FileNotFoundError()
+        self.assertFalse(_is_installed_with_pipx())
+
+    @mock.patch("subprocess.run")
+    def test_is_installed_with_pipx_python_m(self, mock_run):
+        """Test pipx installation detection with python -m pipx."""
+        # First call fails, second succeeds
+        mock_run.side_effect = [
+            FileNotFoundError(),
+            mock.MagicMock(returncode=0, stdout=json.dumps({"venvs": {"caylent-devcontainer-cli": {}}})),
+        ]
+        self.assertTrue(_is_installed_with_pipx())
+
+    def test_is_editable_installation(self):
+        """Test editable installation detection."""
+        result = _is_editable_installation()
+        self.assertIsInstance(result, bool)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx", return_value=True)
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation", return_value=False)
+    def test_get_installation_type_display_pipx(self, mock_editable, mock_pipx):
+        """Test installation type display for pipx."""
+        result = _get_installation_type_display()
+        self.assertEqual(result, "pipx")
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx", return_value=True)
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation", return_value=True)
+    def test_get_installation_type_display_pipx_editable(self, mock_editable, mock_pipx):
+        """Test installation type display for pipx editable."""
+        result = _get_installation_type_display()
+        self.assertEqual(result, "pipx editable")
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx", return_value=False)
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation", return_value=True)
+    def test_get_installation_type_display_pip_editable(self, mock_editable, mock_pipx):
+        """Test installation type display for pip editable."""
+        result = _get_installation_type_display()
+        self.assertEqual(result, "pip editable")
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx", return_value=False)
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_editable_installation", return_value=False)
+    def test_get_installation_type_display_pip(self, mock_editable, mock_pipx):
+        """Test installation type display for pip."""
+        result = _get_installation_type_display()
+        self.assertEqual(result, "pip")
+
+    @mock.patch("sys.stdin.isatty", return_value=False)
+    @mock.patch("sys.stdout.isatty", return_value=True)
+    def test_is_interactive_shell_no_stdin_tty(self, mock_stdout, mock_stdin):
+        """Test interactive shell detection without stdin TTY."""
+        self.assertFalse(_is_interactive_shell())
+
+    @mock.patch("sys.stdin.isatty", return_value=True)
+    @mock.patch("sys.stdout.isatty", return_value=True)
+    def test_is_interactive_shell_both_tty(self, mock_stdout, mock_stdin):
+        """Test interactive shell detection with both TTY."""
+        self.assertTrue(_is_interactive_shell())
+
+    @mock.patch("sys.argv", ["pytest"])
+    @mock.patch("sys.stdin.isatty", return_value=False)
+    def test_is_interactive_shell_pytest_no_tty(self, mock_stdin):
+        """Test pytest without TTY detection."""
+        self.assertFalse(_is_interactive_shell())
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_get_latest_version_network_error(self, mock_urlopen):
+        """Test version fetch with network error."""
+        from urllib.error import URLError
+
+        mock_urlopen.side_effect = URLError("Network error")
+        version = _get_latest_version()
+        self.assertIsNone(version)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_get_latest_version_http_error(self, mock_urlopen):
+        """Test version fetch with HTTP error."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 404
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+        version = _get_latest_version()
+        self.assertIsNone(version)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_get_latest_version_oversized_response(self, mock_urlopen):
+        """Test version fetch with oversized response."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        large_data = "x" * (201 * 1024)
+        mock_response.read.return_value = large_data.encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+        version = _get_latest_version()
+        self.assertIsNone(version)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_get_latest_version_invalid_json(self, mock_urlopen):
+        """Test version fetch with invalid JSON."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = b"invalid json"
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+        version = _get_latest_version()
+        self.assertIsNone(version)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_get_latest_version_key_error(self, mock_urlopen):
+        """Test version fetch with missing key."""
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = json.dumps({"info": {}}).encode()
+        mock_urlopen.return_value.__enter__.return_value = mock_response
+        version = _get_latest_version()
+        self.assertIsNone(version)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version.urlopen")
+    def test_get_latest_version_socket_timeout(self, mock_urlopen):
+        """Test version fetch with socket timeout."""
+        import socket
+
+        mock_urlopen.side_effect = socket.timeout()
+        version = _get_latest_version()
+        self.assertIsNone(version)
+
+    def test_version_is_newer_invalid_versions(self):
+        """Test version comparison with invalid versions."""
+        result = _version_is_newer("invalid", "1.0.0")
+        self.assertFalse(result)
+
+    @mock.patch.dict(os.environ, {"CDEVCONTAINER_DEBUG_UPDATE": "1"})
+    @mock.patch("sys.stderr")
+    def test_debug_log_enabled(self, mock_stderr):
+        """Test debug logging when enabled."""
+        _debug_log("test message")
+        mock_stderr.write.assert_called()
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    @mock.patch("sys.stderr")
+    def test_debug_log_disabled(self, mock_stderr):
+        """Test debug logging when disabled."""
+        _debug_log("test message")
+        mock_stderr.write.assert_not_called()
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_interactive_shell", return_value=False)
+    def test_check_for_updates_non_interactive(self, mock_interactive):
+        """Test update check in non-interactive environment."""
+        result = check_for_updates()
+        self.assertTrue(result)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_interactive_shell", return_value=True)
+    @mock.patch("caylent_devcontainer_cli.utils.version._get_latest_version", return_value=None)
+    def test_check_for_updates_no_version(self, mock_get_version, mock_interactive):
+        """Test update check when version fetch fails."""
+        result = check_for_updates()
+        self.assertTrue(result)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_interactive_shell", return_value=True)
+    @mock.patch("caylent_devcontainer_cli.utils.version._get_latest_version", return_value="1.0.0")
+    @mock.patch("caylent_devcontainer_cli.utils.version._version_is_newer", return_value=False)
+    @mock.patch("builtins.print")
+    def test_check_for_updates_up_to_date(self, mock_print, mock_newer, mock_get_version, mock_interactive):
+        """Test update check when already up to date."""
+        result = check_for_updates()
+        self.assertTrue(result)
+        mock_print.assert_called()
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_interactive_shell", return_value=True)
+    @mock.patch("caylent_devcontainer_cli.utils.version._get_latest_version", return_value="2.0.0")
+    @mock.patch("caylent_devcontainer_cli.utils.version._version_is_newer", return_value=True)
+    @mock.patch("caylent_devcontainer_cli.utils.version._show_update_prompt", return_value=EXIT_OK)
+    def test_check_for_updates_continue(self, mock_prompt, mock_newer, mock_get_version, mock_interactive):
+        """Test update check with continue choice."""
+        result = check_for_updates()
+        self.assertTrue(result)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_interactive_shell", return_value=True)
+    @mock.patch("caylent_devcontainer_cli.utils.version._get_latest_version", return_value="2.0.0")
+    @mock.patch("caylent_devcontainer_cli.utils.version._version_is_newer", return_value=True)
+    @mock.patch("caylent_devcontainer_cli.utils.version._show_update_prompt", return_value=EXIT_UPGRADE_REQUESTED_ABORT)
+    @mock.patch("sys.exit")
+    def test_check_for_updates_exit(self, mock_exit, mock_prompt, mock_newer, mock_get_version, mock_interactive):
+        """Test update check with exit choice."""
+        check_for_updates()
+        mock_exit.assert_called_with(EXIT_UPGRADE_REQUESTED_ABORT)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_interactive_shell", return_value=True)
+    @mock.patch("caylent_devcontainer_cli.utils.version._get_latest_version", side_effect=Exception("error"))
+    def test_check_for_updates_exception(self, mock_get_version, mock_interactive):
+        """Test update check with exception."""
+        result = check_for_updates()
+        self.assertTrue(result)
+
+    @mock.patch("subprocess.run")
+    def test_is_installed_with_pipx_timeout(self, mock_run):
+        """Test pipx detection with timeout."""
+        import subprocess
+
+        mock_run.side_effect = subprocess.TimeoutExpired("pipx", 10)
+        result = _is_installed_with_pipx()
+        self.assertFalse(result)
+
+    @mock.patch("subprocess.run")
+    def test_is_installed_with_pipx_json_error(self, mock_run):
+        """Test pipx detection with JSON decode error."""
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "invalid json"
+        mock_run.return_value = mock_result
+        result = _is_installed_with_pipx()
+        self.assertFalse(result)
+
+    @mock.patch("subprocess.run")
+    def test_is_installed_with_pipx_called_process_error(self, mock_run):
+        """Test pipx detection with CalledProcessError."""
+        import subprocess
+
+        mock_run.side_effect = subprocess.CalledProcessError(1, "pipx")
+        result = _is_installed_with_pipx()
+        self.assertFalse(result)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx", return_value=True)
+    @mock.patch("os.walk")
+    def test_is_editable_installation_pipx_with_egg_link(self, mock_walk, mock_pipx):
+        """Test editable installation detection with pipx and egg-link."""
+        mock_walk.return_value = [("/path", [], ["test.egg-link"])]
+        result = _is_editable_installation()
+        self.assertTrue(result)
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx", return_value=True)
+    @mock.patch("os.walk")
+    def test_is_editable_installation_pipx_no_egg_link(self, mock_walk, mock_pipx):
+        """Test editable installation detection with pipx but no egg-link."""
+        mock_walk.return_value = [("/path", [], ["other.file"])]
+        result = _is_editable_installation()
+        self.assertFalse(result)
+
+    def test_is_editable_installation_exception(self):
+        """Test editable installation detection with exception."""
+        with mock.patch("caylent_devcontainer_cli.utils.version._is_installed_with_pipx", side_effect=Exception()):
+            result = _is_editable_installation()
+            self.assertFalse(result)

--- a/caylent-devcontainer-cli/tests/unit/test_version_debug.py
+++ b/caylent-devcontainer-cli/tests/unit/test_version_debug.py
@@ -1,0 +1,63 @@
+"""Tests for debug logging and error handling in version checking."""
+
+import os
+import unittest.mock as mock
+from io import StringIO
+from unittest import TestCase
+
+from caylent_devcontainer_cli.utils.version import (
+    _debug_log,
+    check_for_updates,
+)
+
+
+class TestDebugLogging(TestCase):
+    """Test debug logging functionality."""
+
+    @mock.patch.dict(os.environ, {"CDEVCONTAINER_DEBUG_UPDATE": "1"})
+    @mock.patch("sys.stderr", new_callable=StringIO)
+    def test_debug_log_enabled(self, mock_stderr):
+        """Test debug logging when enabled."""
+        _debug_log("test message")
+        self.assertIn("DEBUG: test message", mock_stderr.getvalue())
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    @mock.patch("sys.stderr", new_callable=StringIO)
+    def test_debug_log_disabled(self, mock_stderr):
+        """Test debug logging when disabled."""
+        _debug_log("test message")
+        self.assertEqual("", mock_stderr.getvalue())
+
+    @mock.patch.dict(os.environ, {"CDEVCONTAINER_DEBUG_UPDATE": "1"})
+    @mock.patch("sys.stderr", new_callable=StringIO)
+    def test_debug_messages_in_check_for_updates(self, mock_stderr):
+        """Test debug messages are logged during update check."""
+        with mock.patch.dict(os.environ, {"CDEVCONTAINER_SKIP_UPDATE": "1"}):
+            check_for_updates()
+            self.assertIn("Update check skipped (reason: global disable env)", mock_stderr.getvalue())
+
+
+class TestErrorHandlingMatrix(TestCase):
+    """Test specific error handling scenarios from requirements."""
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._get_latest_version")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_interactive_shell")
+    def test_network_timeout_handling(self, mock_interactive, mock_get_version):
+        """Test network timeout is handled silently."""
+        mock_interactive.return_value = True
+        mock_get_version.return_value = None  # Simulates network failure
+
+        result = check_for_updates()
+        self.assertTrue(result)  # Should continue silently
+
+    @mock.patch("caylent_devcontainer_cli.utils.version._version_is_newer")
+    @mock.patch("caylent_devcontainer_cli.utils.version._get_latest_version")
+    @mock.patch("caylent_devcontainer_cli.utils.version._is_interactive_shell")
+    def test_version_parse_error_handling(self, mock_interactive, mock_get_version, mock_version_newer):
+        """Test version parse error handling."""
+        mock_interactive.return_value = True
+        mock_get_version.return_value = "1.12.0"
+        mock_version_newer.return_value = False  # Simulates parse error
+
+        result = check_for_updates()
+        self.assertTrue(result)  # Should treat as no update available


### PR DESCRIPTION
Features added:
- Automatic update checking with manual upgrade instructions
- Installation type detection (pipx, pip, editable) with appropriate guidance
- Interactive prompts to continue or exit for manual upgrade
- CLI flag --skip-update-check and environment variable controls
- Debug logging for troubleshooting update issues
- Automatic skip of update checks in CI/non-interactive environments
- Python module entry point for python -m execution

Documentation added:
- Comprehensive update notification behavior documentation
- Manual upgrade instructions by installation type
- Debug mode and environment variable reference

Bugs fixed:
- Remove incorrect --update flag references from README documentation