### PR TITLE
fix: use crane copy for multi-arch image mirroring

### DIFF
--- a/.github/workflows/mirror-devcontainer-image.yml
+++ b/.github/workflows/mirror-devcontainer-image.yml
@@ -79,15 +79,15 @@ jobs:
           role-to-assume: ${{ env.IAM_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Authenticate Docker to ECR Public
+      - name: Authenticate crane to ECR Public
         if: steps.check.outputs.changed == 'true'
         shell: bash
         run: |
           set -euo pipefail
           aws ecr-public get-login-password --region "${AWS_REGION}" \
-            | docker login --username AWS --password-stdin public.ecr.aws
+            | crane auth login --username AWS --password-stdin public.ecr.aws
 
-      - name: Pull, tag, and push image
+      - name: Copy image to ECR Public
         if: steps.check.outputs.changed == 'true'
         shell: bash
         run: |
@@ -96,20 +96,11 @@ jobs:
           ECR_TARGET="public.ecr.aws/${ECR_ALIAS}/${ECR_REPO}"
           VERSION_TAG="${IMAGE_TAG}-${{ steps.check.outputs.short_sha }}"
 
-          echo "Pulling ${SOURCE_IMAGE}..."
-          docker pull "${SOURCE_IMAGE}"
+          echo "Copying ${SOURCE_IMAGE} -> ${ECR_TARGET}:${IMAGE_TAG}..."
+          crane copy "${SOURCE_IMAGE}" "${ECR_TARGET}:${IMAGE_TAG}"
 
-          echo "Tagging as ${ECR_TARGET}:${IMAGE_TAG}..."
-          docker tag "${SOURCE_IMAGE}" "${ECR_TARGET}:${IMAGE_TAG}"
-
-          echo "Tagging as ${ECR_TARGET}:${VERSION_TAG}..."
-          docker tag "${SOURCE_IMAGE}" "${ECR_TARGET}:${VERSION_TAG}"
-
-          echo "Pushing ${ECR_TARGET}:${IMAGE_TAG}..."
-          docker push "${ECR_TARGET}:${IMAGE_TAG}"
-
-          echo "Pushing ${ECR_TARGET}:${VERSION_TAG}..."
-          docker push "${ECR_TARGET}:${VERSION_TAG}"
+          echo "Copying ${SOURCE_IMAGE} -> ${ECR_TARGET}:${VERSION_TAG}..."
+          crane copy "${SOURCE_IMAGE}" "${ECR_TARGET}:${VERSION_TAG}"
 
           echo "Mirror complete"
 


### PR DESCRIPTION
## Summary

- Replace `docker pull/tag/push` with `crane copy` in the mirror workflow
- Replace `docker login` with `crane auth login` for ECR Public authentication

## Why

`docker pull` on the GitHub runner only pulls the single-platform image (amd64). `docker push` then fails with:

```
image was found but does not provide any platform
```

`crane copy` copies the entire multi-arch manifest list directly between registries without pulling layers locally. This preserves both amd64 and arm64 platforms and is more efficient (server-side copy).

## Test plan

- [ ] Merge to main
- [ ] Actions tab → "Mirror DevContainer Base Image" → "Run workflow" on `main`
- [ ] Verify the copy step succeeds with both platform tags