### PR TITLE
fix(cli): revert version for semantic-release auto-bump and fix license metadata

### DIFF
--- a/caylent-devcontainer-cli/pyproject.toml
+++ b/caylent-devcontainer-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "caylent-devcontainer-cli"
-version = "2.0.0"
+version = "1.14.1"
 description = "CLI tool for managing Caylent devcontainers"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/caylent-devcontainer-cli/src/caylent_devcontainer_cli/__init__.py
+++ b/caylent-devcontainer-cli/src/caylent_devcontainer_cli/__init__.py
@@ -1,3 +1,3 @@
 """Caylent Devcontainer CLI package."""
 
-__version__ = "2.0.0"
+__version__ = "1.14.1"


### PR DESCRIPTION
## Summary
- Revert version from `2.0.0` to `1.14.1` so the `create-release` pipeline can compute the correct major bump (`2.0.0`) from the `feat!:` conventional commit
- License field already fixed on main (`license = {text = "Apache-2.0"}`) to resolve the `twine check` failure caused by PEP 639 `license-expression` metadata

## Context
The PyPI publish workflow failed because `twine 6.1` does not recognize the `license-expression` metadata field emitted by `setuptools>=78` from the string-form `license = "Apache-2.0"`. The dict-form produces the legacy `License` metadata field that twine validates.

The version was manually set to `2.0.0` during the v2.0.0 release, bypassing the `create-release` pipeline. Reverting to `1.14.1` allows semantic-release to auto-compute `2.0.0` from the breaking change commit and manage the full release lifecycle (version bump, changelog, tag, publish).

## Test plan
- [ ] PR validation passes (lint, unit tests, functional tests, build)
- [ ] After merge, `main-validation` triggers and QA approval gates the release
- [ ] `create-release` job computes version `2.0.0` from `feat!:` commit
- [ ] `publish.yml` succeeds with `twine check` passing on the fixed license field