### PR TITLE
fix(ci): upgrade CodeQL Action from v3 to v4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,11 +21,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:python"

--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -208,12 +208,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:python"
 


### PR DESCRIPTION
## Summary

- Upgrade `github/codeql-action/init` and `github/codeql-action/analyze` from v3 to v4 in both `codeql-analysis.yml` and `main-validation.yml`
- CodeQL Action v3 will be deprecated in December 2026: https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

## Test plan

- [ ] Verify CodeQL Analysis workflow runs successfully on this PR