### PR TITLE
fix(ci): add concurrency group to prevent release pipeline race conditions

### DIFF
--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: release-pipeline
+  cancel-in-progress: false
+
 jobs:
   validate:
     name: Validate Main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release-pipeline
+  cancel-in-progress: false
+
 jobs:
   validate-version:
     name: Validate version format


### PR DESCRIPTION
## Summary

- Add `concurrency: group: release-pipeline` with `cancel-in-progress: false` to both `main-validation.yml` and `publish.yml`
- Serializes pipeline runs so multiple merges to main are processed in order
- Prevents race conditions where concurrent runs compute the same version and fail on empty commits

## Test plan

- [ ] Merge two PRs in quick succession and verify the second pipeline queues instead of running concurrently