### PR TITLE
feat(cli): add CLAUDE_CODE_ENABLED toggle for Claude Code CLI installation

### DIFF
--- a/.devcontainer/.devcontainer.postcreate.sh
+++ b/.devcontainer/.devcontainer.postcreate.sh
@@ -344,54 +344,60 @@ fi
 log_info "Installing AWS SSO utilities..."
 install_with_pipx "aws-sso-util"
 
-###################
-# Claude Code CLI #
-###################
-log_info "Installing Claude Code CLI..."
+#####################
+# Claude Code CLI   #
+#####################
+CLAUDE_CODE_ENABLED="${CLAUDE_CODE_ENABLED:-true}"
 
-# Download install script first to ensure it succeeds before piping to bash
-CLAUDE_INSTALL_SCRIPT="/tmp/claude-install-${RANDOM}.sh"
+if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
+  log_info "Installing Claude Code CLI..."
 
-if ! sudo -u "${CONTAINER_USER}" curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
-  exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
-fi
+  # Download install script first to ensure it succeeds before piping to bash
+  CLAUDE_INSTALL_SCRIPT="/tmp/claude-install-${RANDOM}.sh"
 
-# Verify script was downloaded and is not empty
-if [ ! -s "${CLAUDE_INSTALL_SCRIPT}" ]; then
-  exit_with_error "❌ Claude Code install script is empty or missing at ${CLAUDE_INSTALL_SCRIPT}"
-fi
-
-# Execute install script
-log_info "Executing Claude Code install script..."
-if uname -r | grep -i microsoft > /dev/null; then
-  # WSL compatibility: Run directly without sudo -u
-  if ! PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" bash "${CLAUDE_INSTALL_SCRIPT}"; then
-    rm -f "${CLAUDE_INSTALL_SCRIPT}"
-    exit_with_error "❌ Failed to execute Claude Code install script"
+  if ! sudo -u "${CONTAINER_USER}" curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
+    exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
   fi
+
+  # Verify script was downloaded and is not empty
+  if [ ! -s "${CLAUDE_INSTALL_SCRIPT}" ]; then
+    exit_with_error "❌ Claude Code install script is empty or missing at ${CLAUDE_INSTALL_SCRIPT}"
+  fi
+
+  # Execute install script
+  log_info "Executing Claude Code install script..."
+  if uname -r | grep -i microsoft > /dev/null; then
+    # WSL compatibility: Run directly without sudo -u
+    if ! PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" bash "${CLAUDE_INSTALL_SCRIPT}"; then
+      rm -f "${CLAUDE_INSTALL_SCRIPT}"
+      exit_with_error "❌ Failed to execute Claude Code install script"
+    fi
+  else
+    # Non-WSL: Install as container user
+    if ! sudo -u "${CONTAINER_USER}" PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" bash "${CLAUDE_INSTALL_SCRIPT}"; then
+      rm -f "${CLAUDE_INSTALL_SCRIPT}"
+      exit_with_error "❌ Failed to execute Claude Code install script"
+    fi
+  fi
+
+  # Clean up install script
+  rm -f "${CLAUDE_INSTALL_SCRIPT}"
+
+  log_info "Verifying Claude Code CLI installation..."
+  CLAUDE_BIN="/home/${CONTAINER_USER}/.local/bin/claude"
+  if [ ! -f "$CLAUDE_BIN" ]; then
+    exit_with_error "❌ Claude Code binary not found at expected location: $CLAUDE_BIN"
+  fi
+
+  if [ ! -x "$CLAUDE_BIN" ]; then
+    exit_with_error "❌ Claude Code binary exists but is not executable: $CLAUDE_BIN"
+  fi
+
+  CLAUDE_VERSION=$(sudo -u "${CONTAINER_USER}" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
+  log_success "Claude Code CLI installed successfully: ${CLAUDE_VERSION}"
 else
-  # Non-WSL: Install as container user
-  if ! sudo -u "${CONTAINER_USER}" PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" bash "${CLAUDE_INSTALL_SCRIPT}"; then
-    rm -f "${CLAUDE_INSTALL_SCRIPT}"
-    exit_with_error "❌ Failed to execute Claude Code install script"
-  fi
+  log_info "Claude Code CLI installation disabled (CLAUDE_CODE_ENABLED=${CLAUDE_CODE_ENABLED})"
 fi
-
-# Clean up install script
-rm -f "${CLAUDE_INSTALL_SCRIPT}"
-
-log_info "Verifying Claude Code CLI installation..."
-CLAUDE_BIN="/home/${CONTAINER_USER}/.local/bin/claude"
-if [ ! -f "$CLAUDE_BIN" ]; then
-  exit_with_error "❌ Claude Code binary not found at expected location: $CLAUDE_BIN"
-fi
-
-if [ ! -x "$CLAUDE_BIN" ]; then
-  exit_with_error "❌ Claude Code binary exists but is not executable: $CLAUDE_BIN"
-fi
-
-CLAUDE_VERSION=$(sudo -u "${CONTAINER_USER}" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
-log_success "Claude Code CLI installed successfully: ${CLAUDE_VERSION}"
 
 #################
 # Configure Git #

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ These extensions are auto-installed on container start and work with both VS Cod
 
 > ℹ️ **GitHub Copilot is disabled by default** in the default catalog entry. The configuration sets `github.copilot.enable: false` and `chat.extensionUnification.enabled: false` to prevent Copilot from activating. If you prefer to use Claude instead of Copilot and want to fully remove Copilot from VS Code, see [Optional: Removing GitHub Copilot](#optional-removing-github-copilot) for host-level steps.
 
+> To skip Claude Code CLI installation in the devcontainer, set `CLAUDE_CODE_ENABLED` to `false` in your developer profile. The Claude Code VS Code extension remains available but the CLI binary will not be installed. This applies to the default catalog — other catalogs may handle this differently.
+
 ---
 
 ## 🖥 Prerequisites

--- a/caylent-devcontainer-cli/src/caylent_devcontainer_cli/commands/setup.py
+++ b/caylent-devcontainer-cli/src/caylent_devcontainer_cli/commands/setup.py
@@ -20,6 +20,7 @@ from caylent_devcontainer_cli.utils.ui import ask_or_exit, exit_cancelled, exit_
 EXAMPLE_ENV_VALUES = {
     "AWS_CONFIG_ENABLED": "true",
     "AWS_DEFAULT_OUTPUT": "json",
+    "CLAUDE_CODE_ENABLED": "true",
     "DEFAULT_GIT_BRANCH": "main",
     "DEVELOPER_NAME": "Your Name",
     "EXTRA_APT_PACKAGES": "",

--- a/caylent-devcontainer-cli/src/caylent_devcontainer_cli/commands/setup_interactive.py
+++ b/caylent-devcontainer-cli/src/caylent_devcontainer_cli/commands/setup_interactive.py
@@ -101,6 +101,12 @@ def prompt_env_values() -> Dict[str, Any]:
     aws_config = ask_or_exit(questionary.select("Enable AWS configuration?", choices=["true", "false"], default="true"))
     env_values["AWS_CONFIG_ENABLED"] = aws_config
 
+    # Claude Code CLI Enabled
+    claude_code = ask_or_exit(
+        questionary.select("Enable Claude Code CLI installation?", choices=["true", "false"], default="true")
+    )
+    env_values["CLAUDE_CODE_ENABLED"] = claude_code
+
     # CICD mode (always false for interactive setup)
     env_values["CICD"] = "false"
 
@@ -454,8 +460,8 @@ def create_template_interactive() -> Dict[str, Any]:
 
     Steps:
     1. AWS config enabled (select)
-    2. Default Git branch (text)
-    3. Default Python version (text)
+    2. Claude Code CLI enabled (select)
+    3. Default Git branch (text)
     4. Developer name (text)
     5. Git provider URL (text, hostname only)
     6. Git authentication method (select)
@@ -490,7 +496,17 @@ def create_template_interactive() -> Dict[str, Any]:
     )
     env_values["AWS_CONFIG_ENABLED"] = aws_config
 
-    # Step 2: Default Git branch
+    # Step 2: Claude Code CLI enabled
+    claude_code_enabled = prompt_with_confirmation(
+        lambda: questionary.select(
+            "Enable Claude Code CLI installation?",
+            choices=["true", "false"],
+            default="true",
+        )
+    )
+    env_values["CLAUDE_CODE_ENABLED"] = claude_code_enabled
+
+    # Step 3: Default Git branch
     git_branch = prompt_with_confirmation(
         lambda: questionary.text(
             "Default Git branch:",

--- a/caylent-devcontainer-cli/src/caylent_devcontainer_cli/utils/constants.py
+++ b/caylent-devcontainer-cli/src/caylent_devcontainer_cli/utils/constants.py
@@ -102,6 +102,7 @@ REQUIRED_TEMPLATE_KEYS = (
 VALID_KEY_VALUES = {
     "AWS_CONFIG_ENABLED": ("true", "false"),
     "AWS_DEFAULT_OUTPUT": ("json", "table", "text", "yaml"),
+    "CLAUDE_CODE_ENABLED": ("true", "false"),
     "GIT_AUTH_METHOD": ("token", "ssh"),
     "HOST_PROXY": ("true", "false"),
     "PAGER": ("cat", "less", "more", "most"),
@@ -141,6 +142,7 @@ KNOWN_KEYS = frozenset(
     {
         "AWS_CONFIG_ENABLED",
         "AWS_DEFAULT_OUTPUT",
+        "CLAUDE_CODE_ENABLED",
         "DEFAULT_GIT_BRANCH",
         "DEVELOPER_NAME",
         "EXTRA_APT_PACKAGES",

--- a/caylent-devcontainer-cli/tests/functional/test_code_command.py
+++ b/caylent-devcontainer-cli/tests/functional/test_code_command.py
@@ -9,6 +9,7 @@ import tempfile
 _FULL_CONTAINER_ENV = {
     "AWS_CONFIG_ENABLED": "true",
     "AWS_DEFAULT_OUTPUT": "json",
+    "CLAUDE_CODE_ENABLED": "true",
     "DEFAULT_GIT_BRANCH": "main",
     "DEVELOPER_NAME": "test",
     "EXTRA_APT_PACKAGES": "",

--- a/caylent-devcontainer-cli/tests/functional/test_devcontainer_config.py
+++ b/caylent-devcontainer-cli/tests/functional/test_devcontainer_config.py
@@ -129,6 +129,18 @@ class TestPostcreateScript(TestCase):
         """CICD must be read from runtime environment, not shell.env."""
         self.assertIn('CICD_VALUE="${CICD:-false}"', self.content)
 
+    def test_claude_code_enabled_default_true(self):
+        """CLAUDE_CODE_ENABLED must default to true from runtime environment."""
+        self.assertIn('CLAUDE_CODE_ENABLED="${CLAUDE_CODE_ENABLED:-true}"', self.content)
+
+    def test_claude_code_install_conditional(self):
+        """Claude Code CLI install must be conditional on CLAUDE_CODE_ENABLED."""
+        self.assertIn('"${CLAUDE_CODE_ENABLED,,}" = "true"', self.content)
+
+    def test_claude_code_skip_log_message(self):
+        """Postcreate must log when Claude Code CLI installation is skipped."""
+        self.assertIn("Claude Code CLI installation disabled", self.content)
+
     def test_no_sleep_commands(self):
         """Postcreate must not contain any sleep commands."""
         for i, line in enumerate(self.content.splitlines(), 1):

--- a/caylent-devcontainer-cli/tests/functional/test_template_create.py
+++ b/caylent-devcontainer-cli/tests/functional/test_template_create.py
@@ -171,25 +171,26 @@ class TestCreateTemplateInteractiveEndToEnd:
 
         pwc_values = [
             "true" if aws_enabled else "false",  # 1. AWS_CONFIG_ENABLED
-            "develop",  # 2. DEFAULT_GIT_BRANCH
-            "Jane Doe",  # 3. DEVELOPER_NAME
-            "gitlab.com",  # 4. GIT_PROVIDER_URL
-            "token",  # 5. GIT_AUTH_METHOD
-            "jdoe",  # 6. GIT_USER
-            "jane@example.com",  # 7. GIT_USER_EMAIL
-            "glpat-xxxx",  # 8. GIT_TOKEN
-            "vim",  # 9. EXTRA_APT_PACKAGES
-            "less",  # 10. PAGER
+            "true",  # 2. CLAUDE_CODE_ENABLED
+            "develop",  # 3. DEFAULT_GIT_BRANCH
+            "Jane Doe",  # 4. DEVELOPER_NAME
+            "gitlab.com",  # 5. GIT_PROVIDER_URL
+            "token",  # 6. GIT_AUTH_METHOD
+            "jdoe",  # 7. GIT_USER
+            "jane@example.com",  # 8. GIT_USER_EMAIL
+            "glpat-xxxx",  # 9. GIT_TOKEN
+            "vim",  # 10. EXTRA_APT_PACKAGES
+            "less",  # 11. PAGER
         ]
 
         if aws_enabled:
-            pwc_values.append("yaml")  # 11. AWS_DEFAULT_OUTPUT
+            pwc_values.append("yaml")  # 12. AWS_DEFAULT_OUTPUT
 
         if host_proxy:
-            pwc_values.append("true")  # 12. HOST_PROXY
-            pwc_values.append("https://proxy.internal:8080")  # 13. HOST_PROXY_URL
+            pwc_values.append("true")  # 13. HOST_PROXY
+            pwc_values.append("https://proxy.internal:8080")  # 14. HOST_PROXY_URL
         else:
-            pwc_values.append("false")  # 12. HOST_PROXY
+            pwc_values.append("false")  # 13. HOST_PROXY
 
         idx = [0]
 

--- a/caylent-devcontainer-cli/tests/functional/test_template_load.py
+++ b/caylent-devcontainer-cli/tests/functional/test_template_load.py
@@ -96,6 +96,7 @@ class TestLoadTemplateEndToEnd:
         env = {
             "AWS_CONFIG_ENABLED": "false",
             "AWS_DEFAULT_OUTPUT": "json",
+            "CLAUDE_CODE_ENABLED": "true",
             "DEFAULT_GIT_BRANCH": "main",
             "DEVELOPER_NAME": "Test User",
             "EXTRA_APT_PACKAGES": "",

--- a/caylent-devcontainer-cli/tests/functional/test_template_upgrade.py
+++ b/caylent-devcontainer-cli/tests/functional/test_template_upgrade.py
@@ -82,6 +82,7 @@ def _base_container_env():
     return {
         "AWS_CONFIG_ENABLED": "true",
         "AWS_DEFAULT_OUTPUT": "json",
+        "CLAUDE_CODE_ENABLED": "true",
         "DEFAULT_GIT_BRANCH": "main",
         "DEVELOPER_NAME": "Test User",
         "EXTRA_APT_PACKAGES": "",

--- a/caylent-devcontainer-cli/tests/functional/test_template_utilities.py
+++ b/caylent-devcontainer-cli/tests/functional/test_template_utilities.py
@@ -92,6 +92,7 @@ class TestValidateTemplateEndToEnd:
             "containerEnv": {
                 "AWS_CONFIG_ENABLED": "true",
                 "AWS_DEFAULT_OUTPUT": "json",
+                "CLAUDE_CODE_ENABLED": "true",
                 "DEFAULT_GIT_BRANCH": "main",
                 "DEVELOPER_NAME": "Test Dev",
                 "EXTRA_APT_PACKAGES": "",

--- a/caylent-devcontainer-cli/tests/functional/test_validate_template.py
+++ b/caylent-devcontainer-cli/tests/functional/test_validate_template.py
@@ -18,6 +18,7 @@ def _full_template(**overrides):
         "containerEnv": {
             "AWS_CONFIG_ENABLED": "true",
             "AWS_DEFAULT_OUTPUT": "json",
+            "CLAUDE_CODE_ENABLED": "true",
             "DEFAULT_GIT_BRANCH": "main",
             "DEVELOPER_NAME": "Functional Test",
             "EXTRA_APT_PACKAGES": "",

--- a/caylent-devcontainer-cli/tests/unit/test_pager_aws_output.py
+++ b/caylent-devcontainer-cli/tests/unit/test_pager_aws_output.py
@@ -18,7 +18,7 @@ def test_prompt_env_values_none_pager(mock_select, mock_text, mock_password):
     """Test prompt_env_values with None response for pager selection."""
     from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
 
-    mock_select.return_value.ask.side_effect = ["true", None]
+    mock_select.return_value.ask.side_effect = ["true", "true", None]
     mock_text.return_value.ask.side_effect = [
         "main",
         "Developer",
@@ -40,7 +40,7 @@ def test_prompt_env_values_none_aws_output(mock_select, mock_text, mock_password
     """Test prompt_env_values with None response for AWS output format."""
     from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
 
-    mock_select.return_value.ask.side_effect = ["true", "cat", None]
+    mock_select.return_value.ask.side_effect = ["true", "true", "cat", None]
     mock_text.return_value.ask.side_effect = [
         "main",
         "Developer",
@@ -65,7 +65,7 @@ def test_pager_selection_options(mock_select, mock_text, mock_password):
     pager_options = ["cat", "less", "more", "most"]
 
     for pager in pager_options:
-        mock_select.return_value.ask.side_effect = ["false", pager]
+        mock_select.return_value.ask.side_effect = ["false", "true", pager]
         mock_text.return_value.ask.side_effect = [
             "main",
             "Developer",
@@ -90,7 +90,7 @@ def test_aws_output_selection_options(mock_select, mock_text, mock_password):
     aws_output_options = ["json", "table", "text", "yaml"]
 
     for output_format in aws_output_options:
-        mock_select.return_value.ask.side_effect = ["true", "cat", output_format]
+        mock_select.return_value.ask.side_effect = ["true", "true", "cat", output_format]
         mock_text.return_value.ask.side_effect = [
             "main",
             "Developer",
@@ -112,8 +112,8 @@ def test_aws_output_not_prompted_when_aws_disabled(mock_select, mock_text, mock_
     """Test that AWS output format is not prompted when AWS is disabled."""
     from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
 
-    # Only two select calls: AWS config (false) and pager (cat)
-    mock_select.return_value.ask.side_effect = ["false", "cat"]
+    # Three select calls: AWS config (false), Claude Code (true), and pager (cat)
+    mock_select.return_value.ask.side_effect = ["false", "true", "cat"]
     mock_text.return_value.ask.side_effect = [
         "main",
         "Developer",
@@ -130,8 +130,8 @@ def test_aws_output_not_prompted_when_aws_disabled(mock_select, mock_text, mock_
     assert result["PAGER"] == "cat"
     assert "AWS_DEFAULT_OUTPUT" not in result
 
-    # Verify that select was only called twice (AWS config and pager)
-    assert mock_select.return_value.ask.call_count == 2
+    # Verify that select was called three times (AWS config, Claude Code, and pager)
+    assert mock_select.return_value.ask.call_count == 3
 
 
 @patch("questionary.password")
@@ -141,8 +141,8 @@ def test_default_values_selection(mock_select, mock_text, mock_password):
     """Test that default values are properly set for pager and AWS output."""
     from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
 
-    # Test with AWS enabled - should get both pager and AWS output prompts
-    mock_select.return_value.ask.side_effect = ["true", "cat", "json"]
+    # Test with AWS enabled - should get Claude Code, pager and AWS output prompts
+    mock_select.return_value.ask.side_effect = ["true", "true", "cat", "json"]
     mock_text.return_value.ask.side_effect = [
         "main",
         "Developer",

--- a/caylent-devcontainer-cli/tests/unit/test_setup_interactive.py
+++ b/caylent-devcontainer-cli/tests/unit/test_setup_interactive.py
@@ -272,7 +272,7 @@ def test_prompt_env_values_complete_with_aws_enabled(mock_select, mock_text, moc
     """Test prompt_env_values with complete input and AWS enabled."""
     from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
 
-    mock_select.return_value.ask.side_effect = ["true", "less", "table"]
+    mock_select.return_value.ask.side_effect = ["true", "true", "less", "table"]
     mock_text.return_value.ask.side_effect = [
         "main",
         "Developer",
@@ -286,6 +286,7 @@ def test_prompt_env_values_complete_with_aws_enabled(mock_select, mock_text, moc
     result = prompt_env_values()
 
     assert result["AWS_CONFIG_ENABLED"] == "true"
+    assert result["CLAUDE_CODE_ENABLED"] == "true"
     assert result["CICD"] == "false"
     assert result["DEFAULT_GIT_BRANCH"] == "main"
     assert result["DEVELOPER_NAME"] == "Developer"
@@ -305,7 +306,7 @@ def test_prompt_env_values_complete_with_aws_disabled(mock_select, mock_text, mo
     """Test prompt_env_values with complete input and AWS disabled."""
     from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
 
-    mock_select.return_value.ask.side_effect = ["false", "cat"]
+    mock_select.return_value.ask.side_effect = ["false", "true", "cat"]
     mock_text.return_value.ask.side_effect = [
         "main",
         "Developer",
@@ -319,9 +320,56 @@ def test_prompt_env_values_complete_with_aws_disabled(mock_select, mock_text, mo
     result = prompt_env_values()
 
     assert result["AWS_CONFIG_ENABLED"] == "false"
+    assert result["CLAUDE_CODE_ENABLED"] == "true"
     assert result["PAGER"] == "cat"
     assert result["CICD"] == "false"
     assert "AWS_DEFAULT_OUTPUT" not in result
+
+
+@patch("questionary.password")
+@patch("questionary.text")
+@patch("questionary.select")
+def test_prompt_env_values_claude_code_enabled_true(mock_select, mock_text, mock_password):
+    """Test prompt_env_values includes CLAUDE_CODE_ENABLED=true when selected."""
+    from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
+
+    mock_select.return_value.ask.side_effect = ["true", "true", "less", "table"]
+    mock_text.return_value.ask.side_effect = [
+        "main",
+        "Developer",
+        "github.com",
+        "user",
+        "user@example.com",
+        "curl wget",
+    ]
+    mock_password.return_value.ask.return_value = "token123"
+
+    result = prompt_env_values()
+
+    assert result["CLAUDE_CODE_ENABLED"] == "true"
+
+
+@patch("questionary.password")
+@patch("questionary.text")
+@patch("questionary.select")
+def test_prompt_env_values_claude_code_enabled_false(mock_select, mock_text, mock_password):
+    """Test prompt_env_values includes CLAUDE_CODE_ENABLED=false when selected."""
+    from caylent_devcontainer_cli.commands.setup_interactive import prompt_env_values
+
+    mock_select.return_value.ask.side_effect = ["true", "false", "less", "table"]
+    mock_text.return_value.ask.side_effect = [
+        "main",
+        "Developer",
+        "github.com",
+        "user",
+        "user@example.com",
+        "curl wget",
+    ]
+    mock_password.return_value.ask.return_value = "token123"
+
+    result = prompt_env_values()
+
+    assert result["CLAUDE_CODE_ENABLED"] == "false"
 
 
 @patch("questionary.select")

--- a/caylent-devcontainer-cli/tests/unit/test_template_create.py
+++ b/caylent-devcontainer-cli/tests/unit/test_template_create.py
@@ -365,16 +365,17 @@ class TestCreateTemplateInteractiveTokenFlow:
         # Steps 1-17 with token auth
         pwc_values = [
             "true" if aws_enabled else "false",  # 1. AWS_CONFIG_ENABLED
-            "main",  # 2. DEFAULT_GIT_BRANCH
-            "Test Developer",  # 3. DEVELOPER_NAME
-            "github.com",  # 4. GIT_PROVIDER_URL
-            "token",  # 5. GIT_AUTH_METHOD
-            "testuser",  # 6. GIT_USER
-            "test@example.com",  # 7. GIT_USER_EMAIL
-            "ghp_test_token_123",  # 8. GIT_TOKEN (password)
-            # Step 9 skipped (token auth, not SSH)
-            "",  # 10. EXTRA_APT_PACKAGES
-            "cat",  # 11. PAGER
+            "true",  # 2. CLAUDE_CODE_ENABLED
+            "main",  # 3. DEFAULT_GIT_BRANCH
+            "Test Developer",  # 4. DEVELOPER_NAME
+            "github.com",  # 5. GIT_PROVIDER_URL
+            "token",  # 6. GIT_AUTH_METHOD
+            "testuser",  # 7. GIT_USER
+            "test@example.com",  # 8. GIT_USER_EMAIL
+            "ghp_test_token_123",  # 9. GIT_TOKEN (password)
+            # Step 10 skipped (token auth, not SSH)
+            "",  # 11. EXTRA_APT_PACKAGES
+            "cat",  # 12. PAGER
         ]
 
         if aws_enabled:
@@ -521,18 +522,19 @@ class TestCreateTemplateInteractiveSshFlow:
 
         pwc_values = [
             "true",  # 1. AWS_CONFIG_ENABLED
-            "main",  # 2. DEFAULT_GIT_BRANCH
-            "Test Developer",  # 3. DEVELOPER_NAME
-            "github.com",  # 4. GIT_PROVIDER_URL
-            "ssh",  # 5. GIT_AUTH_METHOD
-            "testuser",  # 6. GIT_USER
-            "test@example.com",  # 7. GIT_USER_EMAIL
-            # Step 8 skipped (SSH, not token)
-            # Step 9 handled by prompt_ssh_key mock
-            "",  # 10. EXTRA_APT_PACKAGES
-            "cat",  # 11. PAGER
-            "json",  # 12. AWS_DEFAULT_OUTPUT
-            "false",  # 13. HOST_PROXY
+            "true",  # 2. CLAUDE_CODE_ENABLED
+            "main",  # 3. DEFAULT_GIT_BRANCH
+            "Test Developer",  # 4. DEVELOPER_NAME
+            "github.com",  # 5. GIT_PROVIDER_URL
+            "ssh",  # 6. GIT_AUTH_METHOD
+            "testuser",  # 7. GIT_USER
+            "test@example.com",  # 8. GIT_USER_EMAIL
+            # Step 9 skipped (SSH, not token)
+            # Step 10 handled by prompt_ssh_key mock
+            "",  # 11. EXTRA_APT_PACKAGES
+            "cat",  # 12. PAGER
+            "json",  # 13. AWS_DEFAULT_OUTPUT
+            "false",  # 14. HOST_PROXY
         ]
 
         with (

--- a/caylent-devcontainer-cli/tests/unit/test_template_utils.py
+++ b/caylent-devcontainer-cli/tests/unit/test_template_utils.py
@@ -122,6 +122,7 @@ class TestValidateTemplate:
             "containerEnv": {
                 "AWS_CONFIG_ENABLED": "true",
                 "AWS_DEFAULT_OUTPUT": "json",
+                "CLAUDE_CODE_ENABLED": "true",
                 "DEFAULT_GIT_BRANCH": "main",
                 "DEVELOPER_NAME": "Test Dev",
                 "EXTRA_APT_PACKAGES": "",

--- a/caylent-devcontainer-cli/tests/unit/test_validate_template.py
+++ b/caylent-devcontainer-cli/tests/unit/test_validate_template.py
@@ -23,6 +23,7 @@ def _valid_template(**overrides):
         "containerEnv": {
             "AWS_CONFIG_ENABLED": "true",
             "AWS_DEFAULT_OUTPUT": "json",
+            "CLAUDE_CODE_ENABLED": "true",
             "DEFAULT_GIT_BRANCH": "main",
             "DEVELOPER_NAME": "Test Dev",
             "EXTRA_APT_PACKAGES": "",
@@ -299,6 +300,35 @@ class TestKnownKeyValueValidation:
         with patch("questionary.select", return_value=mock_question):
             result = validate_template(template)
         assert result["containerEnv"]["AWS_CONFIG_ENABLED"] == "true"
+
+    def test_claude_code_enabled_valid_true(self):
+        """CLAUDE_CODE_ENABLED=true passes validation without prompts."""
+        template = _valid_template()
+        template["containerEnv"]["CLAUDE_CODE_ENABLED"] = "true"
+        with patch("questionary.select") as mock:
+            result = validate_template(template)
+            mock.assert_not_called()
+        assert result["containerEnv"]["CLAUDE_CODE_ENABLED"] == "true"
+
+    def test_claude_code_enabled_valid_false(self):
+        """CLAUDE_CODE_ENABLED=false passes validation without prompts."""
+        template = _valid_template()
+        template["containerEnv"]["CLAUDE_CODE_ENABLED"] = "false"
+        with patch("questionary.select") as mock:
+            result = validate_template(template)
+            mock.assert_not_called()
+        assert result["containerEnv"]["CLAUDE_CODE_ENABLED"] == "false"
+
+    def test_claude_code_enabled_invalid_prompts(self):
+        """Invalid CLAUDE_CODE_ENABLED prompts for correction."""
+        template = _valid_template()
+        template["containerEnv"]["CLAUDE_CODE_ENABLED"] = "yes"
+
+        mock_question = MagicMock()
+        mock_question.ask.return_value = "true"
+        with patch("questionary.select", return_value=mock_question):
+            result = validate_template(template)
+        assert result["containerEnv"]["CLAUDE_CODE_ENABLED"] == "true"
 
     def test_host_proxy_invalid_prompts(self):
         """Invalid HOST_PROXY prompts for correction."""

--- a/caylent-devcontainer-cli/tests/unit/test_validation.py
+++ b/caylent-devcontainer-cli/tests/unit/test_validation.py
@@ -403,6 +403,19 @@ class TestStep0BaseKeyCheck:
 
         assert result.missing_base_keys == {}
 
+    def test_claude_code_enabled_in_known_keys(self):
+        """CLAUDE_CODE_ENABLED must be in KNOWN_KEYS."""
+        from caylent_devcontainer_cli.utils.constants import KNOWN_KEYS
+
+        assert "CLAUDE_CODE_ENABLED" in KNOWN_KEYS
+
+    def test_claude_code_enabled_in_valid_key_values(self):
+        """CLAUDE_CODE_ENABLED must be in VALID_KEY_VALUES with true/false."""
+        from caylent_devcontainer_cli.utils.constants import VALID_KEY_VALUES
+
+        assert "CLAUDE_CODE_ENABLED" in VALID_KEY_VALUES
+        assert VALID_KEY_VALUES["CLAUDE_CODE_ENABLED"] == ("true", "false")
+
 
 # =============================================================================
 # detect_validation_issues — Step 1 tests

--- a/common/devcontainer-assets/.devcontainer.postcreate.sh
+++ b/common/devcontainer-assets/.devcontainer.postcreate.sh
@@ -344,54 +344,60 @@ fi
 log_info "Installing AWS SSO utilities..."
 install_with_pipx "aws-sso-util"
 
-###################
-# Claude Code CLI #
-###################
-log_info "Installing Claude Code CLI..."
+#####################
+# Claude Code CLI   #
+#####################
+CLAUDE_CODE_ENABLED="${CLAUDE_CODE_ENABLED:-true}"
 
-# Download install script first to ensure it succeeds before piping to bash
-CLAUDE_INSTALL_SCRIPT="/tmp/claude-install-${RANDOM}.sh"
+if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
+  log_info "Installing Claude Code CLI..."
 
-if ! sudo -u "${CONTAINER_USER}" curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
-  exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
-fi
+  # Download install script first to ensure it succeeds before piping to bash
+  CLAUDE_INSTALL_SCRIPT="/tmp/claude-install-${RANDOM}.sh"
 
-# Verify script was downloaded and is not empty
-if [ ! -s "${CLAUDE_INSTALL_SCRIPT}" ]; then
-  exit_with_error "❌ Claude Code install script is empty or missing at ${CLAUDE_INSTALL_SCRIPT}"
-fi
-
-# Execute install script
-log_info "Executing Claude Code install script..."
-if uname -r | grep -i microsoft > /dev/null; then
-  # WSL compatibility: Run directly without sudo -u
-  if ! PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" bash "${CLAUDE_INSTALL_SCRIPT}"; then
-    rm -f "${CLAUDE_INSTALL_SCRIPT}"
-    exit_with_error "❌ Failed to execute Claude Code install script"
+  if ! sudo -u "${CONTAINER_USER}" curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
+    exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
   fi
+
+  # Verify script was downloaded and is not empty
+  if [ ! -s "${CLAUDE_INSTALL_SCRIPT}" ]; then
+    exit_with_error "❌ Claude Code install script is empty or missing at ${CLAUDE_INSTALL_SCRIPT}"
+  fi
+
+  # Execute install script
+  log_info "Executing Claude Code install script..."
+  if uname -r | grep -i microsoft > /dev/null; then
+    # WSL compatibility: Run directly without sudo -u
+    if ! PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" bash "${CLAUDE_INSTALL_SCRIPT}"; then
+      rm -f "${CLAUDE_INSTALL_SCRIPT}"
+      exit_with_error "❌ Failed to execute Claude Code install script"
+    fi
+  else
+    # Non-WSL: Install as container user
+    if ! sudo -u "${CONTAINER_USER}" PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" bash "${CLAUDE_INSTALL_SCRIPT}"; then
+      rm -f "${CLAUDE_INSTALL_SCRIPT}"
+      exit_with_error "❌ Failed to execute Claude Code install script"
+    fi
+  fi
+
+  # Clean up install script
+  rm -f "${CLAUDE_INSTALL_SCRIPT}"
+
+  log_info "Verifying Claude Code CLI installation..."
+  CLAUDE_BIN="/home/${CONTAINER_USER}/.local/bin/claude"
+  if [ ! -f "$CLAUDE_BIN" ]; then
+    exit_with_error "❌ Claude Code binary not found at expected location: $CLAUDE_BIN"
+  fi
+
+  if [ ! -x "$CLAUDE_BIN" ]; then
+    exit_with_error "❌ Claude Code binary exists but is not executable: $CLAUDE_BIN"
+  fi
+
+  CLAUDE_VERSION=$(sudo -u "${CONTAINER_USER}" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
+  log_success "Claude Code CLI installed successfully: ${CLAUDE_VERSION}"
 else
-  # Non-WSL: Install as container user
-  if ! sudo -u "${CONTAINER_USER}" PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" bash "${CLAUDE_INSTALL_SCRIPT}"; then
-    rm -f "${CLAUDE_INSTALL_SCRIPT}"
-    exit_with_error "❌ Failed to execute Claude Code install script"
-  fi
+  log_info "Claude Code CLI installation disabled (CLAUDE_CODE_ENABLED=${CLAUDE_CODE_ENABLED})"
 fi
-
-# Clean up install script
-rm -f "${CLAUDE_INSTALL_SCRIPT}"
-
-log_info "Verifying Claude Code CLI installation..."
-CLAUDE_BIN="/home/${CONTAINER_USER}/.local/bin/claude"
-if [ ! -f "$CLAUDE_BIN" ]; then
-  exit_with_error "❌ Claude Code binary not found at expected location: $CLAUDE_BIN"
-fi
-
-if [ ! -x "$CLAUDE_BIN" ]; then
-  exit_with_error "❌ Claude Code binary exists but is not executable: $CLAUDE_BIN"
-fi
-
-CLAUDE_VERSION=$(sudo -u "${CONTAINER_USER}" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
-log_success "Claude Code CLI installed successfully: ${CLAUDE_VERSION}"
 
 #################
 # Configure Git #


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_ENABLED` environment variable (default: `true`) to allow developers to skip Claude Code CLI installation via their developer profile
- Follows the same pattern as `AWS_CONFIG_ENABLED` — conditional in postcreate script, prompt in `template create`, validation in constants/template utils
- The VS Code extension (`anthropic.claude-code`) remains available regardless — only the CLI binary installation is toggled
- This applies to the default catalog only — other catalogs can have different common files and behavior
- Update README with info box explaining the toggle

## Test plan
- [ ] Verify 1174 tests pass (unit + functional)
- [ ] Verify lint passes (`make lint`)
- [ ] Verify postcreate scripts are identical (`.devcontainer/` and `common/devcontainer-assets/`)
- [ ] Verify existing developer profiles without `CLAUDE_CODE_ENABLED` still install Claude CLI (backward compatible default)
- [ ] Verify `cdevcontainer template create` prompts for Claude Code CLI enablement