### PR TITLE
fix(ci): provide GitHub App token to check-release step

### DIFF
--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -23,6 +23,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate token from GitHub App
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -133,6 +140,8 @@ jobs:
       - name: Check if release is needed
         id: check-release
         working-directory: ${{ github.workspace }}/caylent-devcontainer-cli
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           CURRENT_VERSION=$(python -c "import importlib.metadata; print(importlib.metadata.version('caylent-devcontainer-cli'))")
           echo "Current version: $CURRENT_VERSION"
@@ -147,6 +156,9 @@ jobs:
             echo "Version bump detected: $CURRENT_VERSION → $NEW_VERSION"
             echo "has_release=true" >> "$GITHUB_OUTPUT"
           fi
+
+          echo "GITHUB_OUTPUT contents:"
+          cat "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Send success notification to Slack


### PR DESCRIPTION
## Summary
- Add GitHub App token generation (`tibdex/github-app-token@v2`) to the `validate` job, matching the existing pattern in `create-release`
- Pass `GH_TOKEN` to the `check-release` step so `semantic_release version --print` can properly access the GitHub API
- Add debug logging (`cat $GITHUB_OUTPUT`) to verify outputs are written correctly

## Context
After #141, the `check-release` step correctly computed `has_release=true` but the `manual-approval` job was skipped. The GitHub API showed the `validate` job's outputs as `null`. The `check-release` step was running `semantic_release` without a `GH_TOKEN`, which produced a warning about an empty token and likely prevented job outputs from propagating.

## Test plan
- [ ] This is a `fix(ci)` commit — pipeline should skip release (validates skip path)
- [ ] Check CI logs for `GITHUB_OUTPUT contents:` line to confirm output is written
- [ ] Next `feat`/`fix` merge should trigger QA approval and release (validates release path)