### PR TITLE
fix: add WSL-conditional paths for Claude Code download and version check

### DIFF
--- a/.devcontainer/.devcontainer.postcreate.sh
+++ b/.devcontainer/.devcontainer.postcreate.sh
@@ -340,8 +340,15 @@ if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
   # Download install script first to ensure it succeeds before piping to bash
   CLAUDE_INSTALL_SCRIPT="/tmp/claude-install-${RANDOM}.sh"
 
-  if ! sudo -u "${CONTAINER_USER}" curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
-    exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
+  if uname -r | grep -i microsoft > /dev/null; then
+    # WSL compatibility: Run directly without sudo -u
+    if ! curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
+      exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
+    fi
+  else
+    if ! sudo -u "${CONTAINER_USER}" curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
+      exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
+    fi
   fi
 
   # Verify script was downloaded and is not empty
@@ -378,7 +385,12 @@ if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
     exit_with_error "❌ Claude Code binary exists but is not executable: $CLAUDE_BIN"
   fi
 
-  CLAUDE_VERSION=$(sudo -u "${CONTAINER_USER}" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
+  if uname -r | grep -i microsoft > /dev/null; then
+    # WSL compatibility: Run directly without sudo -u
+    CLAUDE_VERSION=$(PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
+  else
+    CLAUDE_VERSION=$(sudo -u "${CONTAINER_USER}" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
+  fi
   log_success "Claude Code CLI installed successfully: ${CLAUDE_VERSION}"
 else
   log_info "Claude Code CLI installation disabled (CLAUDE_CODE_ENABLED=${CLAUDE_CODE_ENABLED})"

--- a/.devcontainer/.devcontainer.postcreate.sh
+++ b/.devcontainer/.devcontainer.postcreate.sh
@@ -340,7 +340,7 @@ if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
   # Download install script first to ensure it succeeds before piping to bash
   CLAUDE_INSTALL_SCRIPT="/tmp/claude-install-${RANDOM}.sh"
 
-  if uname -r | grep -i microsoft > /dev/null; then
+  if is_wsl; then
     # WSL compatibility: Run directly without sudo -u
     if ! curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
       exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
@@ -358,7 +358,7 @@ if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
 
   # Execute install script
   log_info "Executing Claude Code install script..."
-  if uname -r | grep -i microsoft > /dev/null; then
+  if is_wsl; then
     # WSL compatibility: Run directly without sudo -u
     if ! PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" bash "${CLAUDE_INSTALL_SCRIPT}"; then
       rm -f "${CLAUDE_INSTALL_SCRIPT}"
@@ -385,7 +385,7 @@ if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
     exit_with_error "❌ Claude Code binary exists but is not executable: $CLAUDE_BIN"
   fi
 
-  if uname -r | grep -i microsoft > /dev/null; then
+  if is_wsl; then
     # WSL compatibility: Run directly without sudo -u
     CLAUDE_VERSION=$(PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
   else

--- a/common/devcontainer-assets/.devcontainer.postcreate.sh
+++ b/common/devcontainer-assets/.devcontainer.postcreate.sh
@@ -340,8 +340,15 @@ if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
   # Download install script first to ensure it succeeds before piping to bash
   CLAUDE_INSTALL_SCRIPT="/tmp/claude-install-${RANDOM}.sh"
 
-  if ! sudo -u "${CONTAINER_USER}" curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
-    exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
+  if uname -r | grep -i microsoft > /dev/null; then
+    # WSL compatibility: Run directly without sudo -u
+    if ! curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
+      exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
+    fi
+  else
+    if ! sudo -u "${CONTAINER_USER}" curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
+      exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
+    fi
   fi
 
   # Verify script was downloaded and is not empty
@@ -378,7 +385,12 @@ if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
     exit_with_error "❌ Claude Code binary exists but is not executable: $CLAUDE_BIN"
   fi
 
-  CLAUDE_VERSION=$(sudo -u "${CONTAINER_USER}" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
+  if uname -r | grep -i microsoft > /dev/null; then
+    # WSL compatibility: Run directly without sudo -u
+    CLAUDE_VERSION=$(PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
+  else
+    CLAUDE_VERSION=$(sudo -u "${CONTAINER_USER}" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
+  fi
   log_success "Claude Code CLI installed successfully: ${CLAUDE_VERSION}"
 else
   log_info "Claude Code CLI installation disabled (CLAUDE_CODE_ENABLED=${CLAUDE_CODE_ENABLED})"

--- a/common/devcontainer-assets/.devcontainer.postcreate.sh
+++ b/common/devcontainer-assets/.devcontainer.postcreate.sh
@@ -340,7 +340,7 @@ if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
   # Download install script first to ensure it succeeds before piping to bash
   CLAUDE_INSTALL_SCRIPT="/tmp/claude-install-${RANDOM}.sh"
 
-  if uname -r | grep -i microsoft > /dev/null; then
+  if is_wsl; then
     # WSL compatibility: Run directly without sudo -u
     if ! curl -fsSL https://claude.ai/install.sh -o "${CLAUDE_INSTALL_SCRIPT}"; then
       exit_with_error "❌ Failed to download Claude Code install script from https://claude.ai/install.sh - check network connectivity and proxy settings"
@@ -358,7 +358,7 @@ if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
 
   # Execute install script
   log_info "Executing Claude Code install script..."
-  if uname -r | grep -i microsoft > /dev/null; then
+  if is_wsl; then
     # WSL compatibility: Run directly without sudo -u
     if ! PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" bash "${CLAUDE_INSTALL_SCRIPT}"; then
       rm -f "${CLAUDE_INSTALL_SCRIPT}"
@@ -385,7 +385,7 @@ if [ "${CLAUDE_CODE_ENABLED,,}" = "true" ]; then
     exit_with_error "❌ Claude Code binary exists but is not executable: $CLAUDE_BIN"
   fi
 
-  if uname -r | grep -i microsoft > /dev/null; then
+  if is_wsl; then
     # WSL compatibility: Run directly without sudo -u
     CLAUDE_VERSION=$(PATH="/home/${CONTAINER_USER}/.local/bin:$PATH" "${CLAUDE_BIN}" --version 2>&1 || echo "unknown")
   else


### PR DESCRIPTION
## Summary

- The Claude Code CLI install section in `.devcontainer.postcreate.sh` used `sudo -u` unconditionally for the **download** (`curl`) and **version check** (`--version`) steps
- `sudo -u` is unreliable in WSL environments — this is why the **execution** step already had WSL-conditional logic
- This fix applies the same WSL-conditional pattern to the download and version verification steps

## Files changed

| File | Change |
|------|--------|
| `.devcontainer/.devcontainer.postcreate.sh` | WSL-conditional download + version check |
| `common/devcontainer-assets/.devcontainer.postcreate.sh` | Same fix (common template) |

## Test plan

- [x] `bash -n` syntax validation passes on both files
- [x] `diff` confirms `.devcontainer/` and `common/` copies are in sync
- [ ] Verify CI pipeline passes
- [ ] Rebuild devcontainer on WSL and verify Claude Code installs successfully